### PR TITLE
Add `GetConn` method for session

### DIFF
--- a/session_common.go
+++ b/session_common.go
@@ -31,6 +31,11 @@ type SessionCommon struct {
 	log logrus.FieldLogger
 }
 
+// GetConn returns underlying TCP `net.Conn`.
+func (sc *SessionCommon) GetConn() net.Conn {
+	return sc.netConn
+}
+
 func (sc *SessionCommon) initClient(entity *EntityCommon, conn net.Conn, rPK cipher.PubKey) error {
 	ns, err := noise.New(noise.HandshakeXK, noise.Config{
 		LocalPK:   entity.pk,


### PR DESCRIPTION
Related to https://github.com/skycoin/skywire/issues/138

 Changes:	
- Added `GetConn` method to session

Intention is to get the `net.Conn` object, to later extract the socket file descriptor. At least it is required for Android app to work, probably will be required for iOS one too.