### PR TITLE
Add /health endpoint to dmsg discovery

### DIFF
--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -47,6 +47,7 @@ func New(log logrus.FieldLogger, db store.Storer, testMode bool) *API {
 	}
 	mux.HandleFunc("/dmsg-discovery/entry/", api.muxEntry())
 	mux.HandleFunc("/dmsg-discovery/available_servers", api.getAvailableServers())
+	mux.HandleFunc("/dmsg-discovery/health", api.health())
 	return api
 }
 
@@ -188,6 +189,14 @@ func (a *API) getAvailableServers() http.HandlerFunc {
 
 		a.writeJSON(w, http.StatusOK, entries)
 	}
+}
+
+// health returns status of dmsg discovery
+// URI: /dmsg-discovery/health
+// Method: GET
+func (a *API) health() http.HandlerFunc {
+	const expBase = "health"
+	return httputil.MakeHealthHandler(a.log, expBase, nil)
 }
 
 // isLoopbackAddr checks if string is loopback interface


### PR DESCRIPTION
WIP on https://github.com/SkycoinPro/skywire-services/issues/170

 Changes:	
- Add /health endpoint to dmsg discovery

How to test this PR:
- Run the integration env
- Perform `GET localhost:9090/dmsg-discovery/health` request, the status should be equal to `200`.