### PR TITLE
Make client's `Serve` cancellable from outside

### DIFF
--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -196,7 +196,7 @@ var rootCmd = &cobra.Command{
 		dmsgC := dmsg.NewClient(pk, sk, disc.NewHTTP(dmsgDisc), &dmsg.Config{
 			MinSessions: dmsgSessions,
 		})
-		go dmsgC.Serve()
+		go dmsgC.Serve(context.Background())
 		select {
 		case <-ctx.Done():
 			cmdutil.CatchWithLog(log, "failed to wait unti dmsg client to be ready", ctx.Err())

--- a/dmsgget/dmsgget.go
+++ b/dmsgget/dmsgget.go
@@ -191,7 +191,7 @@ func parseOutputFile(name string, urlPath string) (*os.File, error) {
 
 func (dg *DmsgGet) startDmsg(ctx context.Context, log logrus.FieldLogger, pk cipher.PubKey, sk cipher.SecKey) (dmsgC *dmsg.Client, stop func(), err error) {
 	dmsgC = dmsg.NewClient(pk, sk, disc.NewHTTP(dg.dmsgF.Disc), &dmsg.Config{MinSessions: dg.dmsgF.Sessions})
-	go dmsgC.Serve()
+	go dmsgC.Serve(context.Background())
 
 	stop = func() {
 		err := dmsgC.Close()

--- a/dmsgget/dmsgget_test.go
+++ b/dmsgget/dmsgget_test.go
@@ -1,6 +1,7 @@
 package dmsgget
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -133,7 +134,7 @@ func runHTTPSrv(t *testing.T, dc disc.APIClient, fName string) string {
 	httpPath := filepath.Base(fName)
 
 	dmsgC := dmsg.NewClient(pk, sk, dc, nil)
-	go dmsgC.Serve()
+	go dmsgC.Serve(context.Background())
 	t.Cleanup(func() { assert.NoError(t, dmsgC.Close()) })
 	<-dmsgC.Ready()
 
@@ -163,7 +164,7 @@ func newHTTPClient(t *testing.T, dc disc.APIClient) *http.Client {
 	pk, sk := cipher.GenerateKeyPair()
 
 	dmsgC := dmsg.NewClient(pk, sk, dc, nil)
-	go dmsgC.Serve()
+	go dmsgC.Serve(context.Background())
 	t.Cleanup(func() { assert.NoError(t, dmsgC.Close()) })
 	<-dmsgC.Ready()
 

--- a/dmsghttp/examples_test.go
+++ b/dmsghttp/examples_test.go
@@ -1,6 +1,7 @@
 package dmsghttp_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -54,7 +55,7 @@ func ExampleMakeHTTPTransport() {
 			panic(err)
 		}
 	}()
-	go dmsgC1.Serve()
+	go dmsgC1.Serve(context.Background())
 	<-dmsgC1.Ready()
 
 	// Host HTTP server via dmsg client 1.
@@ -81,7 +82,7 @@ func ExampleMakeHTTPTransport() {
 			panic(err)
 		}
 	}()
-	go dmsgC2.Serve()
+	go dmsgC2.Serve(context.Background())
 	<-dmsgC2.Ready()
 
 	// Run HTTP client.

--- a/dmsghttp/http_transport_test.go
+++ b/dmsghttp/http_transport_test.go
@@ -1,6 +1,7 @@
 package dmsghttp
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -139,7 +140,7 @@ func newDmsgClient(t *testing.T, dc disc.APIClient, minSessions int, name string
 		Callbacks:   nil,
 	})
 	dmsgC.SetLogger(logging.MustGetLogger(name))
-	go dmsgC.Serve()
+	go dmsgC.Serve(context.Background())
 
 	t.Cleanup(func() {
 		assert.NoError(t, dmsgC.Close())

--- a/dmsgtest/env.go
+++ b/dmsgtest/env.go
@@ -146,7 +146,7 @@ func (env *Env) newClientWithKeys(ctx context.Context, pk cipher.PubKey, sk ciph
 	env.cWg.Add(1)
 
 	go func() {
-		c.Serve()
+		c.Serve(context.Background())
 		env.mx.Lock()
 		delete(env.c, pk)
 		env.mx.Unlock()

--- a/examples/basics/main.go
+++ b/examples/basics/main.go
@@ -42,10 +42,10 @@ func main() {
 
 	// instantiate clients
 	respC := dmsg.NewClient(respPK, respSK, dc, nil)
-	go respC.Serve()
+	go respC.Serve(context.Background())
 
 	initC := dmsg.NewClient(initPK, initSK, dc, nil)
-	go initC.Serve()
+	go initC.Serve(context.Background())
 
 	time.Sleep(time.Second)
 

--- a/examples/dmsgget/dmsg-example-http-server/dmsg-example-http-server.go
+++ b/examples/dmsgget/dmsg-example-http-server/dmsg-example-http-server.go
@@ -51,7 +51,7 @@ func main() {
 		}
 	}()
 
-	go c.Serve()
+	go c.Serve(context.Background())
 
 	select {
 	case <-ctx.Done():

--- a/stream_test.go
+++ b/stream_test.go
@@ -42,13 +42,13 @@ func TestStream(t *testing.T) {
 	pkA, skA := GenKeyPair(t, "client A")
 	clientA := NewClient(pkA, skA, dc, DefaultConfig())
 	clientA.SetLogger(logging.MustGetLogger("client_A"))
-	go clientA.Serve()
+	go clientA.Serve(context.Background())
 
 	// Prepare and serve dmsg client B.
 	pkB, skB := GenKeyPair(t, "client B")
 	clientB := NewClient(pkB, skB, dc, DefaultConfig())
 	clientB.SetLogger(logging.MustGetLogger("client_B"))
-	go clientB.Serve()
+	go clientB.Serve(context.Background())
 
 	// Ensure all entities are registered in discovery before continuing.
 	time.Sleep(time.Second * 2)


### PR DESCRIPTION
Part of #472

 Changes:	
- Now `Serve` accepts outer context, therefore may be cancelled from outside

This is done to let outer code interrupt visor startup
