### PR TITLE
Set entry timeout for newer versions only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 install:
   - go get -u github.com/FiloSottile/vendorcheck
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.31.0
   - go mod vendor
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
   - go mod vendor
 
 script:
-  - make test
+  - make check

--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -57,7 +57,13 @@ func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry) error {
 		return disc.ErrUnexpected
 	}
 
-	err = r.client.Set(entry.Static.Hex(), payload, r.timeout).Err()
+	// v0.3.0 visors send entry.NeedTimeout == true, visors up to v0.2.4 do not.
+	timeout := time.Duration(0)
+	if entry.NeedTimeout {
+		timeout = r.timeout
+	}
+
+	err = r.client.Set(entry.Static.Hex(), payload, timeout).Err()
 	if err != nil {
 		return disc.ErrUnexpected
 	}

--- a/disc/client.go
+++ b/disc/client.go
@@ -92,8 +92,6 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 	endpoint := c.address + "/dmsg-discovery/entry/"
 	log := log.WithField("endpoint", endpoint)
 
-	e.NeedTimeout = true // v0.3.0+
-
 	marshaledEntry, err := json.Marshal(e)
 	if err != nil {
 		return err

--- a/disc/client.go
+++ b/disc/client.go
@@ -92,6 +92,8 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 	endpoint := c.address + "/dmsg-discovery/entry/"
 	log := log.WithField("endpoint", endpoint)
 
+	e.NeedTimeout = true // v0.3.0+
+
 	marshaledEntry, err := json.Marshal(e)
 	if err != nil {
 		return err

--- a/disc/entry.go
+++ b/disc/entry.go
@@ -118,6 +118,10 @@ type Entry struct {
 
 	// Signature for proving authenticity of an Entry.
 	Signature string `json:"signature,omitempty"`
+
+	// NeedTimeout defines whether a timeout is needed for an entry.
+	// It is used to differentiate visors up to v0.2.3 as their entries do not need a timeout.
+	NeedTimeout bool `json:"need_timeout,omitempty"`
 }
 
 func (e *Entry) String() string {

--- a/disc/entry.go
+++ b/disc/entry.go
@@ -183,22 +183,24 @@ func (s *Server) String() string {
 // should be signed with the private key before sending it to the server
 func NewClientEntry(pubkey cipher.PubKey, sequence uint64, delegatedServers []cipher.PubKey) *Entry {
 	return &Entry{
-		Version:   currentVersion,
-		Sequence:  sequence,
-		Client:    &Client{delegatedServers},
-		Static:    pubkey,
-		Timestamp: time.Now().UnixNano(),
+		Version:     currentVersion,
+		Sequence:    sequence,
+		Client:      &Client{delegatedServers},
+		Static:      pubkey,
+		Timestamp:   time.Now().UnixNano(),
+		NeedTimeout: true, // v0.3.0+
 	}
 }
 
 // NewServerEntry constructs a new Server entry.
 func NewServerEntry(pk cipher.PubKey, seq uint64, addr string, availableSessions int) *Entry {
 	return &Entry{
-		Version:   currentVersion,
-		Sequence:  seq,
-		Server:    &Server{Address: addr, AvailableSessions: availableSessions},
-		Static:    pk,
-		Timestamp: time.Now().UnixNano(),
+		Version:     currentVersion,
+		Sequence:    seq,
+		Server:      &Server{Address: addr, AvailableSessions: availableSessions},
+		Static:      pk,
+		Timestamp:   time.Now().UnixNano(),
+		NeedTimeout: true, // v0.3.0+
 	}
 }
 

--- a/discord/discord.go
+++ b/discord/discord.go
@@ -12,18 +12,20 @@ const (
 	webhookURLEnvName = "DISCORD_WEBHOOK_URL"
 )
 
+// NewHook creates a new Discord hook.
 func NewHook(tag, webHookURL string) logrus.Hook {
 	return discordrus.NewHook(webHookURL, logrus.ErrorLevel, discordOpts(tag))
 }
 
 func discordOpts(tag string) *discordrus.Opts {
 	return &discordrus.Opts{
-		Username:           tag,
-		TimestampFormat:    time.RFC3339,
-		TimestampLocale:    time.UTC,
+		Username:        tag,
+		TimestampFormat: time.RFC3339,
+		TimestampLocale: time.UTC,
 	}
 }
 
+// GetWebhookURLFromEnv extract Discord webhook URL from env.
 func GetWebhookURLFromEnv() string {
 	return os.Getenv(webhookURLEnvName)
 }

--- a/dmsgpty/whitelist.go
+++ b/dmsgpty/whitelist.go
@@ -73,7 +73,7 @@ func (w *jsonFileWhitelist) Remove(pks ...cipher.PubKey) error {
 }
 
 func (w *jsonFileWhitelist) open(perm int, fn func(pkMap map[cipher.PubKey]bool, f *os.File) error) error {
-	f, err := os.OpenFile(w.fileName, perm, 0600)
+	f, err := os.OpenFile(w.fileName, perm, 0600) // nolint:gosec
 	if err != nil {
 		return err
 	}

--- a/dmsgtest/dmsg_client_test.go
+++ b/dmsgtest/dmsg_client_test.go
@@ -184,7 +184,7 @@ func continuousRandomWrite(t *testing.T, conn net.Conn) {
 			close(errCh)
 		}()
 		for {
-			b := cipher.RandByte(rand.Intn(maxLen))
+			b := cipher.RandByte(rand.Intn(maxLen)) // nolint:gosec
 			if _, err := conn.Write(b); err != nil {
 				return
 			}

--- a/noise/net_test.go
+++ b/noise/net_test.go
@@ -299,7 +299,7 @@ func TestConn(t *testing.T) {
 
 		rand.Seed(time.Now().UnixNano())
 		for i := 0; i < 10; i++ {
-			n := rand.Intn(10000000)
+			n := rand.Intn(10000000) // nolint:gosec
 			t.Run(fmt.Sprintf("%dBytes", n), func(t *testing.T) {
 				do(t, n)
 			})


### PR DESCRIPTION
WIP on https://github.com/skycoin/skywire/issues/528

NOTE: After merging this PR, `skywire`'s vendor files should be updated, then  https://github.com/skycoin/skywire/issues/528 will be fixed.

 Changes:	
- Set entry timeout for newer versions only
- Fix linter
- Enable linter in TravisCI

How to test this PR:
- Try to reproduce https://github.com/skycoin/skywire/issues/528 (the changes are uploaded on test deployment)
