### PR TITLE
Add Discord start/stop logs

### DIFF
--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/skycoin/dmsg/cmd/dmsg-discovery/internal/api"
 	"github.com/skycoin/dmsg/cmd/dmsg-discovery/internal/store"
 	"github.com/skycoin/dmsg/cmdutil"
+	"github.com/skycoin/dmsg/discord"
 )
 
 const redisPasswordEnvName = "REDIS_PASSWORD"
@@ -43,6 +44,10 @@ var rootCmd = &cobra.Command{
 		}
 
 		log := sf.Logger()
+
+		// Workaround for Discord logger hook. Actually, it's Info.
+		log.Error(discord.StartLogMessage)
+		defer log.Error(discord.StopLogMessage)
 
 		m := sf.HTTPMetrics()
 

--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
@@ -45,9 +46,14 @@ var rootCmd = &cobra.Command{
 
 		log := sf.Logger()
 
-		// Workaround for Discord logger hook. Actually, it's Info.
-		log.Error(discord.StartLogMessage)
-		defer log.Error(discord.StopLogMessage)
+		if discordWebhookURL := discord.GetWebhookURLFromEnv(); discordWebhookURL != "" {
+			// Workaround for Discord logger hook. Actually, it's Info.
+			log.Error(discord.StartLogMessage)
+			defer log.Error(discord.StopLogMessage)
+		} else {
+			log.Info(discord.StartLogMessage)
+			defer log.Info(discord.StopLogMessage)
+		}
 
 		m := sf.HTTPMetrics()
 

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/cmdutil"
 	"github.com/skycoin/dmsg/disc"
+	"github.com/skycoin/dmsg/discord"
 	"github.com/skycoin/dmsg/promutil"
 	"github.com/skycoin/dmsg/servermetrics"
 )
@@ -31,6 +32,10 @@ var rootCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, args []string) error { return sf.Check() },
 	Run: func(_ *cobra.Command, args []string) {
 		log := sf.Logger()
+
+		// Workaround for Discord logger hook. Actually, it's Info.
+		log.Error(discord.StartLogMessage)
+		defer log.Error(discord.StopLogMessage)
 
 		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
 			log.WithError(err).Warn("Failed to output build info.")

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -31,14 +31,19 @@ var rootCmd = &cobra.Command{
 	Short:   "Dmsg Server for Skywire.",
 	PreRunE: func(cmd *cobra.Command, args []string) error { return sf.Check() },
 	Run: func(_ *cobra.Command, args []string) {
+		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
+			log.Printf("Failed to output build info: %v", err)
+		}
+
 		log := sf.Logger()
 
-		// Workaround for Discord logger hook. Actually, it's Info.
-		log.Error(discord.StartLogMessage)
-		defer log.Error(discord.StopLogMessage)
-
-		if _, err := buildinfo.Get().WriteTo(os.Stdout); err != nil {
-			log.WithError(err).Warn("Failed to output build info.")
+		if discordWebhookURL := discord.GetWebhookURLFromEnv(); discordWebhookURL != "" {
+			// Workaround for Discord logger hook. Actually, it's Info.
+			log.Error(discord.StartLogMessage)
+			defer log.Error(discord.StopLogMessage)
+		} else {
+			log.Info(discord.StartLogMessage)
+			defer log.Info(discord.StopLogMessage)
 		}
 
 		var conf Config

--- a/discord/hook.go
+++ b/discord/hook.go
@@ -16,8 +16,10 @@ const (
 )
 
 const (
+	// StartLogMessage defines a message on binary starting.
 	StartLogMessage = "Starting"
-	StopLogMessage  = "Stopping"
+	// StopLogMessage defines a message on binary stopping.
+	StopLogMessage = "Stopping"
 )
 
 // Hook is a Discord logger hook.


### PR DESCRIPTION
Part of https://github.com/SkycoinPro/skywire-services/issues/245

 Changes:	
- Add Discord start/stop logs

How to test this PR:
- Start any binary providing Discord webhook URL
- Check if start/stop logs appear in Discord
