### PR TITLE
Differentiate v0.3.0 visors by URL query instead of entry

### DIFF
--- a/cmd/dmsg-discovery/internal/api/entries_endpoint_test.go
+++ b/cmd/dmsg-discovery/internal/api/entries_endpoint_test.go
@@ -57,7 +57,7 @@ func TestEntriesEndpoint(t *testing.T) {
 				require.NoError(t, err)
 			},
 			storerPreHook: func(t *testing.T, s store2.Storer, e *disc.Entry) {
-				err := s.SetEntry(context.Background(), e)
+				err := s.SetEntry(context.Background(), e, time.Duration(0))
 				require.NoError(t, err)
 			},
 		},
@@ -109,7 +109,7 @@ func TestEntriesEndpoint(t *testing.T) {
 				e.Sequence = 0
 				err := e.Sign(sk)
 				require.NoError(t, err)
-				err = s.SetEntry(context.Background(), e)
+				err = s.SetEntry(context.Background(), e, time.Duration(0))
 				require.NoError(t, err)
 			},
 		},
@@ -134,7 +134,7 @@ func TestEntriesEndpoint(t *testing.T) {
 				e.Sequence = 1
 				err := e.Sign(sk)
 				require.NoError(t, err)
-				err = s.SetEntry(context.Background(), e)
+				err = s.SetEntry(context.Background(), e, time.Duration(0))
 				require.NoError(t, err)
 			},
 		},
@@ -158,7 +158,7 @@ func TestEntriesEndpoint(t *testing.T) {
 			},
 			storerPreHook: func(t *testing.T, s store2.Storer, e *disc.Entry) {
 				e.Sequence = 0
-				err := s.SetEntry(context.Background(), e)
+				err := s.SetEntry(context.Background(), e, time.Duration(0))
 				require.NoError(t, err)
 			},
 		},

--- a/cmd/dmsg-discovery/internal/api/get_available_servers_test.go
+++ b/cmd/dmsg-discovery/internal/api/get_available_servers_test.go
@@ -74,13 +74,13 @@ func TestGetAvailableServers(t *testing.T) {
 				db, err := store2.NewStore("mock", nil)
 				require.NoError(t, err)
 
-				err = db.SetEntry(context.Background(), &entry1)
+				err = db.SetEntry(context.Background(), &entry1, time.Duration(0))
 				require.NoError(t, err)
 
-				err = db.SetEntry(context.Background(), &entry2)
+				err = db.SetEntry(context.Background(), &entry2, time.Duration(0))
 				require.NoError(t, err)
 
-				err = db.SetEntry(context.Background(), &entry3)
+				err = db.SetEntry(context.Background(), &entry3, time.Duration(0))
 				require.NoError(t, err)
 
 				return db, []*disc.Entry{&entry1, &entry2, &entry3}

--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -51,16 +51,10 @@ func (r *redisStore) Entry(ctx context.Context, staticPubKey cipher.PubKey) (*di
 }
 
 // Entry implements Storer Entry method for redisdb database
-func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry) error {
+func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry, timeout time.Duration) error {
 	payload, err := json.Marshal(entry)
 	if err != nil {
 		return disc.ErrUnexpected
-	}
-
-	// v0.3.0 visors send entry.NeedTimeout == true, visors up to v0.2.4 do not.
-	timeout := time.Duration(0)
-	if entry.NeedTimeout {
-		timeout = r.timeout
 	}
 
 	err = r.client.Set(entry.Static.Hex(), payload, timeout).Err()

--- a/cmd/dmsg-discovery/internal/store/redis_test.go
+++ b/cmd/dmsg-discovery/internal/store/redis_test.go
@@ -38,7 +38,7 @@ func TestRedisStoreClientEntry(t *testing.T) {
 	}
 	require.NoError(t, entry.Sign(sk))
 
-	require.NoError(t, redis.SetEntry(ctx, entry))
+	require.NoError(t, redis.SetEntry(ctx, entry, time.Duration(0)))
 
 	res, err := redis.Entry(ctx, pk)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestRedisStoreServerEntry(t *testing.T) {
 
 	require.NoError(t, entry.Sign(sk))
 
-	require.NoError(t, redis.SetEntry(ctx, entry))
+	require.NoError(t, redis.SetEntry(ctx, entry, time.Duration(0)))
 
 	res, err := redis.Entry(ctx, pk)
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestRedisStoreServerEntry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
 
-	require.NoError(t, redis.SetEntry(ctx, entry))
+	require.NoError(t, redis.SetEntry(ctx, entry, time.Duration(0)))
 
 	entries, err = redis.AvailableServers(ctx, 2)
 	require.NoError(t, err)

--- a/cmd/dmsg-discovery/internal/store/storer.go
+++ b/cmd/dmsg-discovery/internal/store/storer.go
@@ -26,7 +26,7 @@ type Storer interface {
 
 	// SetEntry set's an entry.
 	// This is unsafe and does not check signature.
-	SetEntry(ctx context.Context, entry *disc.Entry) error
+	SetEntry(ctx context.Context, entry *disc.Entry, timeout time.Duration) error
 
 	// AvailableServers discovers available dmsg servers.
 	AvailableServers(ctx context.Context, maxCount int) ([]*disc.Entry, error)

--- a/cmd/dmsg-discovery/internal/store/testing.go
+++ b/cmd/dmsg-discovery/internal/store/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/disc"
@@ -72,7 +73,7 @@ func (ms *MockStore) Entry(ctx context.Context, staticPubKey cipher.PubKey) (*di
 }
 
 // SetEntry implements Storer SetEntry method for MockStore
-func (ms *MockStore) SetEntry(ctx context.Context, entry *disc.Entry) error {
+func (ms *MockStore) SetEntry(ctx context.Context, entry *disc.Entry, timeout time.Duration) error {
 	payload, err := json.Marshal(entry)
 	if err != nil {
 		return disc.ErrUnexpected

--- a/disc/client.go
+++ b/disc/client.go
@@ -54,7 +54,9 @@ func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry
 	if err != nil {
 		return nil, err
 	}
+
 	addKeepAlive(req)
+
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
@@ -101,10 +103,16 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 	if err != nil {
 		return err
 	}
-	addKeepAlive(req)
-	req = req.WithContext(ctx)
 
+	addKeepAlive(req)
 	req.Header.Set("Content-Type", "application/json")
+
+	// Since v0.3.0 visors send ?timeout=true, before v0.3.0 do not.
+	q := req.URL.Query()
+	q.Add("timeout", "true")
+	req.URL.RawQuery = q.Encode()
+
+	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
 	if resp != nil {

--- a/disc/entry.go
+++ b/disc/entry.go
@@ -118,10 +118,6 @@ type Entry struct {
 
 	// Signature for proving authenticity of an Entry.
 	Signature string `json:"signature,omitempty"`
-
-	// NeedTimeout defines whether a timeout is needed for an entry.
-	// It is used to differentiate visors up to v0.2.3 as their entries do not need a timeout.
-	NeedTimeout bool `json:"need_timeout,omitempty"`
 }
 
 func (e *Entry) String() string {
@@ -183,24 +179,22 @@ func (s *Server) String() string {
 // should be signed with the private key before sending it to the server
 func NewClientEntry(pubkey cipher.PubKey, sequence uint64, delegatedServers []cipher.PubKey) *Entry {
 	return &Entry{
-		Version:     currentVersion,
-		Sequence:    sequence,
-		Client:      &Client{delegatedServers},
-		Static:      pubkey,
-		Timestamp:   time.Now().UnixNano(),
-		NeedTimeout: true, // v0.3.0+
+		Version:   currentVersion,
+		Sequence:  sequence,
+		Client:    &Client{delegatedServers},
+		Static:    pubkey,
+		Timestamp: time.Now().UnixNano(),
 	}
 }
 
 // NewServerEntry constructs a new Server entry.
 func NewServerEntry(pk cipher.PubKey, seq uint64, addr string, availableSessions int) *Entry {
 	return &Entry{
-		Version:     currentVersion,
-		Sequence:    seq,
-		Server:      &Server{Address: addr, AvailableSessions: availableSessions},
-		Static:      pk,
-		Timestamp:   time.Now().UnixNano(),
-		NeedTimeout: true, // v0.3.0+
+		Version:   currentVersion,
+		Sequence:  seq,
+		Server:    &Server{Address: addr, AvailableSessions: availableSessions},
+		Static:    pk,
+		Timestamp: time.Now().UnixNano(),
 	}
 }
 


### PR DESCRIPTION
 Changes:	
- Differentiate v0.3.0 visors by URL query instead of entry

How to test this PR:
- The changes are uploaded to test deployment. Both master and develop visors should work correctly with it.
