### PR TITLE
Add build information for deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ dep: ## Sorts dependencies
 build: ## Build binaries into ./bin
 	mkdir -p ${BIN}; go build ${BUILD_OPTS} -o ${BIN} ./cmd/*
 
-build-deploy:
+build-deploy: ## Build for deployment Docker images
 	go build -tags netgo ${BUILD_OPTS_DEPLOY} -o /release/dmsg-discovery ./cmd/dmsg-discovery
 	go build -tags netgo ${BUILD_OPTS_DEPLOY} -o /release/dmsg-server ./cmd/dmsg-server
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ BUILDINFO_VERSION := -X $(BUILDINFO_PATH).version=$(VERSION)
 BUILDINFO_DATE := -X $(BUILDINFO_PATH).date=$(DATE)
 BUILDINFO_COMMIT := -X $(BUILDINFO_PATH).commit=$(COMMIT)
 
-BUILDINFO?=-ldflags="$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)"
+BUILDINFO?=$(BUILDINFO_VERSION) $(BUILDINFO_DATE) $(BUILDINFO_COMMIT)
 
-BUILD_OPTS?=$(BUILDINFO)
+BUILD_OPTS?="-ldflags=$(BUILDINFO)"
+BUILD_OPTS_DEPLOY?="-ldflags=$(BUILDINFO) -w -s"
 
 check: lint test ## Run linters and tests
 
@@ -66,6 +67,10 @@ dep: ## Sorts dependencies
 
 build: ## Build binaries into ./bin
 	mkdir -p ${BIN}; go build ${BUILD_OPTS} -o ${BIN} ./cmd/*
+
+build-deploy:
+	go build -tags netgo ${BUILD_OPTS_DEPLOY} -o /release/dmsg-discovery ./cmd/dmsg-discovery
+	go build -tags netgo ${BUILD_OPTS_DEPLOY} -o /release/dmsg-server ./cmd/dmsg-server
 
 start-db: ## Init local database env.
 	source ./integration/env.sh && init_redis


### PR DESCRIPTION
Part of https://github.com/SkycoinPro/skywire-services/issues/248

 Changes:	
- Add build information for deployment

How to test this PR:
- Run `make build`
- Run compiled files
- Check if they contain build info
- In `make build-deploy` change output folder to something valid
- Run `make build-deploy`
- Run compiled files
- Check if they contain build info