### PR TITLE
Output hostname in Discord hook

### DIFF
--- a/cmdutil/service_flags.go
+++ b/cmdutil/service_flags.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/sirupsen/logrus"
@@ -148,7 +147,8 @@ func (sf *ServiceFlags) Logger() *logging.Logger {
 	}
 
 	if discordWebhookURL := discord.GetWebhookURLFromEnv(); discordWebhookURL != "" {
-		hook := discord.NewHook(sf.Tag, discordWebhookURL, discord.WithLimit(10*time.Minute))
+		discordOpts := discord.GetDefaultOpts()
+		hook := discord.NewHook(sf.Tag, discordWebhookURL, discordOpts...)
 		logging.AddHook(hook)
 	}
 

--- a/discord/hook.go
+++ b/discord/hook.go
@@ -22,9 +22,12 @@ const (
 	StopLogMessage = "Stopping"
 )
 
+// DefaultRateLimiterThreshold defines default rate limiter threshold.
+const DefaultRateLimiterThreshold = 10 * time.Minute
+
 // Hook is a Discord logger hook.
 type Hook struct {
-	logrus.Hook
+	*discordrus.Hook
 	limit      time.Duration
 	timestamps map[string]time.Time
 }
@@ -37,6 +40,13 @@ func WithLimit(limit time.Duration) Option {
 	return func(h *Hook) {
 		h.limit = limit
 		h.timestamps = make(map[string]time.Time)
+	}
+}
+
+// WithAuthor sets log entry author.
+func WithAuthor(author string) Option {
+	return func(h *Hook) {
+		h.Hook.Opts.Author = author
 	}
 }
 
@@ -97,4 +107,14 @@ func discordOpts(tag string) *discordrus.Opts {
 // GetWebhookURLFromEnv extracts webhook URL from an environment variable.
 func GetWebhookURLFromEnv() string {
 	return os.Getenv(webhookURLEnvName)
+}
+
+// GetDefaultOpts returns default options.
+func GetDefaultOpts() []Option {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "<unknown hostname>"
+	}
+
+	return []Option{WithLimit(DefaultRateLimiterThreshold), WithAuthor(hostname)}
 }


### PR DESCRIPTION
Part of https://github.com/SkycoinPro/skywire-services/issues/268

 Changes:	
- Output hostname in Discord hook

How to test this PR:
- Check test deployment logs
