### PR TITLE
Increase allowed entry timestamp error

### DIFF
--- a/disc/entry.go
+++ b/disc/entry.go
@@ -13,7 +13,7 @@ import (
 const (
 	currentVersion             = "0.0.1"
 	entryLifetime              = 1 * time.Minute
-	allowedEntryTimestampError = 100 * time.Millisecond
+	allowedEntryTimestampError = 5 * time.Second
 )
 
 var (


### PR DESCRIPTION
Attempt to fix https://github.com/SkycoinPro/skywire-services/issues/274

 Changes:	
- Increase allowed entry timestamp error from 100 ms to 5 s

How to test this PR:
- `make check`
