### PR TITLE
Remove entry timestamp check

### DIFF
--- a/disc/entry.go
+++ b/disc/entry.go
@@ -271,7 +271,11 @@ func (e *Entry) Validate() error {
 
 	if ts.After(latestAcceptable) || ts.Before(earliestAcceptable) {
 		log.Warnf("Entry timestamp %v is not correct (now: %v)", ts, now)
-		return ErrValidationOutdatedTime
+		// Skybian boards have issues with mismatching time because of https://github.com/skycoin/skybian/issues/47.
+		// This causes issues like https://github.com/SkycoinPro/skywire-services/issues/274.
+		// Therefore, the timestamp check needs to be temporarily disabled until the issue is resolved.
+		//
+		// return ErrValidationOutdatedTime
 	}
 
 	return nil


### PR DESCRIPTION
Temporary workaround to fix https://github.com/SkycoinPro/skywire-services/issues/274

 Changes:	
- Remove entry timestamp check

How to test this PR:
- Run Skybian board
