### PR TITLE
Add validation of Public Key.

### DIFF
--- a/noise/noise.go
+++ b/noise/noise.go
@@ -62,6 +62,12 @@ func New(pattern noise.HandshakePattern, config Config) (*Noise, error) {
 		nc.PeerStatic = config.RemotePK[:]
 	}
 
+	// check if value is correct
+	_, err := cipher.NewPubKey(config.LocalPK[:])
+	if err != nil {
+		return nil, err
+	}
+
 	hs, err := noise.NewHandshakeState(nc)
 	if err != nil {
 		return nil, err

--- a/noise/noise_test.go
+++ b/noise/noise_test.go
@@ -146,13 +146,13 @@ func TestIncorrectPublicKey(t *testing.T) {
 	for i := 0; i < 33; i++ {
 		public = append(public, val)
 	}
-	pkI, err := cipher.NewPubKey(public)
+	pkI, _ := cipher.NewPubKey(public)
 	confI := Config{
 		LocalPK:   pkI,
 		LocalSK:   skI,
 		RemotePK:  pkR,
 		Initiator: true,
 	}
-	_, err = New(HandshakeXK, confI)
+	_, err := New(HandshakeXK, confI)
 	require.Error(t, err)
 }

--- a/noise/noise_test.go
+++ b/noise/noise_test.go
@@ -1,6 +1,7 @@
 package noise
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -137,4 +138,23 @@ func TestXKAndSecp256k1(t *testing.T) {
 	decrypted, err = nR.DecryptUnsafe(encrypted)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("baz"), decrypted)
+}
+func TestIncorrectPublicKey(t *testing.T) {
+	_, skI := cipher.GenerateKeyPair()
+	pkR, _ := cipher.GenerateKeyPair()
+	val := byte(255)
+	public := make([]byte, 0)
+	for i := 0; i < 33; i++ {
+		public = append(public, val)
+	}
+	pkI, err := cipher.NewPubKey(public)
+	fmt.Println(err)
+	confI := Config{
+		LocalPK:   pkI,
+		LocalSK:   skI,
+		RemotePK:  pkR,
+		Initiator: true,
+	}
+	_, err = New(HandshakeXK, confI)
+	require.Error(t, err)
 }

--- a/noise/noise_test.go
+++ b/noise/noise_test.go
@@ -146,13 +146,14 @@ func TestIncorrectPublicKey(t *testing.T) {
 	for i := 0; i < 33; i++ {
 		public = append(public, val)
 	}
-	pkI, _ := cipher.NewPubKey(public)
+	pkI, err := cipher.NewPubKey(public)
+	require.Error(t, err)
 	confI := Config{
 		LocalPK:   pkI,
 		LocalSK:   skI,
 		RemotePK:  pkR,
 		Initiator: true,
 	}
-	_, err := New(HandshakeXK, confI)
+	_, err = New(HandshakeXK, confI)
 	require.Error(t, err)
 }

--- a/noise/noise_test.go
+++ b/noise/noise_test.go
@@ -1,7 +1,6 @@
 package noise
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -148,7 +147,6 @@ func TestIncorrectPublicKey(t *testing.T) {
 		public = append(public, val)
 	}
 	pkI, err := cipher.NewPubKey(public)
-	fmt.Println(err)
 	confI := Config{
 		LocalPK:   pkI,
 		LocalSK:   skI,


### PR DESCRIPTION
Fixes https://github.com/SkycoinPro/skywire-services/issues/308

 Changes:	
-	Add validation to of Public Key in Noise constructor. 

How to test this PR:
Run `go test github.com/skycoin/dmsg/noise`