### PR TITLE
Fix concurrent sessions access panic

### DIFF
--- a/cmd/dmsg-server/internal/api/api.go
+++ b/cmd/dmsg-server/internal/api/api.go
@@ -60,10 +60,10 @@ func New(r *chi.Mux, log *logging.Logger) *API {
 // RunBackgroundTasks is function which runs periodic tasks of dmsg-server.
 func (a *API) RunBackgroundTasks(ctx context.Context) {
 	ticker := time.NewTicker(time.Second * 10)
-	tickerEverySecond := time.NewTicker(time.Second * 1)
+	//tickerEverySecond := time.NewTicker(time.Second * 1)
 	tickerEveryMinute := time.NewTicker(time.Second * 60)
 	defer ticker.Stop()
-	defer tickerEverySecond.Stop()
+	//defer tickerEverySecond.Stop()
 	defer tickerEveryMinute.Stop()
 	a.updateInternalState()
 	for {
@@ -74,8 +74,8 @@ func (a *API) RunBackgroundTasks(ctx context.Context) {
 			a.updateInternalState()
 		case <-tickerEveryMinute.C:
 			a.updateAverageNumberOfPacketsPerMinute()
-		case <-tickerEverySecond.C:
-			a.updateAverageNumberOfPacketsPerSecond()
+			/*case <-tickerEverySecond.C:
+			a.updateAverageNumberOfPacketsPerSecond()*/
 		}
 	}
 }
@@ -140,6 +140,7 @@ func (a *API) updateAverageNumberOfPacketsPerMinute() {
 		a.minuteDecValues = newDecValues
 		a.minuteEncValues = newEncValues
 		a.avgPackagesPerMinute = average
+		a.avgPackagesPerSecond = average / 60
 	}
 }
 

--- a/cmd/dmsg-server/internal/api/api.go
+++ b/cmd/dmsg-server/internal/api/api.go
@@ -144,7 +144,8 @@ func (a *API) updateAverageNumberOfPacketsPerMinute() {
 	}
 }
 
-// UpdateAverageNumberOfPacketsPerSecond is function which needs to called every second.
+// TODO (darkrengarius): reimplement efficiently
+/*// UpdateAverageNumberOfPacketsPerSecond is function which needs to called every second.
 func (a *API) updateAverageNumberOfPacketsPerSecond() {
 	if a.dmsgServer != nil {
 		newDecValues, newEncValues, average := calculateThroughput(
@@ -158,7 +159,8 @@ func (a *API) updateAverageNumberOfPacketsPerSecond() {
 		a.secondEncValues = newEncValues
 		a.avgPackagesPerSecond = average
 	}
-}
+}*/
+
 func calculateThroughput(
 	sessions map[cipher.PubKey]*dmsg.SessionCommon,
 	previousDecValues map[*dmsg.SessionCommon]uint64,

--- a/server.go
+++ b/server.go
@@ -80,7 +80,13 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 func (s *Server) GetSessions() map[cipher.PubKey]*SessionCommon {
 	s.sessionsMx.Lock()
 	defer s.sessionsMx.Unlock()
-	return s.sessions
+
+	sessions := make(map[cipher.PubKey]*SessionCommon, len(s.sessions))
+	for pk, session := range s.sessions {
+		sessions[pk] = session
+	}
+
+	return sessions
 }
 
 // Close implements io.Closer


### PR DESCRIPTION
Changes:	
- Now concurrent access to the sessions map is safe. We don't return the map itself, we return the copy of it;
- Throughput/s is now calculated once per minute by dividing throughput/min by 60. This is done, because copying the sessions map each second is costly