### PR TITLE
Add structured logging middleware

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -86,6 +86,7 @@ func GetLogger(r *http.Request) logrus.FieldLogger {
 
 // todo: investigate if it's used throughout the services (didn't work properly for UT)
 // remove and use structured logging
+
 // SetLoggerMiddleware sets logger to context of HTTP requests.
 func SetLoggerMiddleware(log logrus.FieldLogger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -84,6 +84,8 @@ func GetLogger(r *http.Request) logrus.FieldLogger {
 	return logging.NewMasterLogger()
 }
 
+// todo: investigate if it's used throughout the services (didn't work properly for UT)
+// remove and use structured logging
 // SetLoggerMiddleware sets logger to context of HTTP requests.
 func SetLoggerMiddleware(log logrus.FieldLogger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/httputil/log.go
+++ b/httputil/log.go
@@ -1,0 +1,50 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/middleware"
+	"github.com/sirupsen/logrus"
+)
+
+type structuredLogger struct {
+	logger logrus.FieldLogger
+}
+
+func NewLogMiddleware(logger logrus.FieldLogger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			sl := &structuredLogger{logger}
+			start := time.Now()
+			var requestID string
+			if reqID := r.Context().Value(middleware.RequestIDKey); reqID != nil {
+				requestID = reqID.(string)
+			}
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			newContext := context.WithValue(r.Context(), middleware.LogEntryCtxKey, sl)
+			next.ServeHTTP(ww, r.WithContext(newContext))
+			latency := time.Since(start)
+			fields := logrus.Fields{
+				"status":  ww.Status(),
+				"took":    latency,
+				"remote":  r.RemoteAddr,
+				"request": r.RequestURI,
+				"method":  r.Method,
+			}
+			if requestID != "" {
+				fields["request_id"] = requestID
+			}
+			sl.logger.WithFields(fields).Info()
+
+		}
+		return http.HandlerFunc(fn)
+	}
+}
+
+func LogEntrySetField(r *http.Request, key string, value interface{}) {
+	if sl, ok := r.Context().Value(middleware.LogEntryCtxKey).(*structuredLogger); ok {
+		sl.logger = sl.logger.WithField(key, value)
+	}
+}

--- a/httputil/log.go
+++ b/httputil/log.go
@@ -13,7 +13,7 @@ type structuredLogger struct {
 	logger logrus.FieldLogger
 }
 
-// NewLogMiddleware creates a new instance of logging middleware. This will allow setting
+// NewLogMiddleware creates a new instance of logging middleware. This will allow
 // adding log fields in the handler and any further middleware. At the end of request, this
 // log entry will be printed at Info level via passed logger
 func NewLogMiddleware(logger logrus.FieldLogger) func(http.Handler) http.Handler {

--- a/httputil/log.go
+++ b/httputil/log.go
@@ -13,6 +13,9 @@ type structuredLogger struct {
 	logger logrus.FieldLogger
 }
 
+// NewLogMiddleware creates a new instance of logging middleware. This will allow setting
+// adding log fields in the handler and any further middleware. At the end of request, this
+// log entry will be printed at Info level via passed logger
 func NewLogMiddleware(logger logrus.FieldLogger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
@@ -43,6 +46,9 @@ func NewLogMiddleware(logger logrus.FieldLogger) func(http.Handler) http.Handler
 	}
 }
 
+// LogEntrySetField adds new key-value pair to current (request scoped) log entry. This pair will be
+// printed along with all other pairs when the request is served.
+// This requires log middleware from this package to be installed in the chain
 func LogEntrySetField(r *http.Request, key string, value interface{}) {
 	if sl, ok := r.Context().Value(middleware.LogEntryCtxKey).(*structuredLogger); ok {
 		sl.logger = sl.logger.WithField(key, value)


### PR DESCRIPTION
Structured logging allows adding new fields to log entry, allowing a single entry to be modified from multiple places. Resulting entry then can be parsed and searched for by log storage. Structured logging is supported by logrus (current logging library), but it's not used in http handlers. This middleware and helper function allow this feature.

Fixes no issue were created	

 Changes:	
- add structured logging to httputils package

How to test this PR:
use NewLogMiddleware with chi router. 