### PR TITLE
pr draft - Improve dmsgpty

### DIFF
--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -18,15 +19,14 @@ import (
 
 // struct to read / write from config
 type config struct {
-	SK           cipher.SecKey `json:"-"`
-	SKStr        string        `json:"sk"`
-	Wl           cipher.PubKey `json:"-"`
-	WlStr        string        `json:"wl"`
-	DmsgDisc     string        `json:"dmsgdisc"`
-	DmsgSessions int           `json:"dmsgsessions"`
-	DmsgPort     uint16        `json:"dmsgport"`
-	CLINet       string        `json:"clinet"`
-	CLIAddr      string        `json:"cliaddr"`
+	SK           cipher.SecKey  `json:"-"`
+	SKStr        string         `json:"sk"`
+	Wl           cipher.PubKeys `json:"wl"`
+	DmsgDisc     string         `json:"dmsgdisc"`
+	DmsgSessions int            `json:"dmsgsessions"`
+	DmsgPort     uint16         `json:"dmsgport"`
+	CLINet       string         `json:"clinet"`
+	CLIAddr      string         `json:"cliaddr"`
 }
 
 func defaultConfig() config {
@@ -95,8 +95,10 @@ var rootCmd = &cobra.Command{
 		// store config.json into conf
 		json.Unmarshal(file, &conf)
 
+		fmt.Println(conf)
+
 		// check if config file is newly created
-		if conf.WlStr == "" {
+		if conf.Wl == nil {
 
 			log.Println("adding the wl slice field")
 

--- a/cmd/dmsgpty-cli/commands/whitelist.go
+++ b/cmd/dmsgpty-cli/commands/whitelist.go
@@ -20,11 +20,6 @@ var whitelistCmd = &cobra.Command{
 	Short: "lists all whitelisted public keys",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		// display whitelist slice from config
-		for i := range conf.Whitelist {
-			println(i)
-		}
-
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
 			return err
@@ -50,17 +45,6 @@ var whitelistAddCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		// append passed in public key(s) into config file
-
-		for _, k := range pks {
-			conf.Whitelist = append(conf.Whitelist, k)
-		}
-
-		println(fmt.Sprint(pks))
-
-		// update conf
-		updateFile()
 
 		wlC, err := cli.WhitelistClient()
 		if err != nil {

--- a/cmd/dmsgpty-cli/commands/whitelist.go
+++ b/cmd/dmsgpty-cli/commands/whitelist.go
@@ -19,6 +19,12 @@ var whitelistCmd = &cobra.Command{
 	Use:   "whitelist",
 	Short: "lists all whitelisted public keys",
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		// display whitelist slice from config
+		for i := range conf.Whitelist {
+			println(i)
+		}
+
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
 			return err
@@ -39,10 +45,23 @@ var whitelistAddCmd = &cobra.Command{
 	Short: "adds public key(s) to the whitelist",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
+
 		pks, err := pksFromArgs(args)
 		if err != nil {
 			return err
 		}
+
+		// append passed in public key(s) into config file
+
+		for _, k := range pks {
+			conf.Whitelist = append(conf.Whitelist, k)
+		}
+
+		println(fmt.Sprint(pks))
+
+		// update conf
+		updateFile()
+
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
 			return err

--- a/cmd/dmsgpty-cli/commands/whitelist.go
+++ b/cmd/dmsgpty-cli/commands/whitelist.go
@@ -49,9 +49,28 @@ var whitelistAddCmd = &cobra.Command{
 			return err
 		}
 
+		// duplicate flag
+		var dFlag bool
+
 		// append new pks to the whitelist slice within the config file
 		for _, k := range pks {
-			conf.Wl = append(conf.Wl, k)
+
+			dFlag = false
+
+			for _, p := range conf.Wl {
+				// already exists
+				if p == k {
+					dFlag = true
+					fmt.Printf("skipping append for %v. Already exists", k)
+					break
+				}
+
+			}
+
+			if !dFlag {
+				conf.Wl = append(conf.Wl, k)
+			}
+
 		}
 
 		// write the changes back to the config file
@@ -74,11 +93,30 @@ var whitelistRemoveCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		// for each pubkey to be removed
+		for _, k := range pks {
+
+			// find occurence of pubkey
+			for i := 0; i < len(conf.Wl); i++ {
+
+				// if an occurence is found
+				if k == conf.Wl[i] {
+					// remove element
+					conf.Wl = append(conf.Wl[:i], conf.Wl[i+1:]...)
+				}
+			}
+		}
+
+		// write the changes back to the config file
+		updateFile()
+
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
 			return err
 		}
 		return wlC.WhitelistRemove(pks...)
+
 	},
 }
 

--- a/cmd/dmsgpty-cli/commands/whitelist.go
+++ b/cmd/dmsgpty-cli/commands/whitelist.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -46,6 +49,14 @@ var whitelistAddCmd = &cobra.Command{
 			return err
 		}
 
+		// append new pks to the whitelist slice within the config file
+		for _, k := range pks {
+			conf.Wl = append(conf.Wl, k)
+		}
+
+		// write the changes back to the config file
+		updateFile()
+
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
 			return err
@@ -79,4 +90,25 @@ func pksFromArgs(args []string) ([]cipher.PubKey, error) {
 		}
 	}
 	return pks, nil
+}
+
+// func update config file
+func updateFile() error {
+
+	// marshal content
+	b, err := json.MarshalIndent(conf, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// show changed config
+	os.Stdout.Write(b)
+
+	// write to config.json
+	err = ioutil.WriteFile("config.json", b, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/dmsgpty-host/commands/confgen.go
+++ b/cmd/dmsgpty-host/commands/confgen.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/skycoin/dmsg/cipher"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -12,17 +13,50 @@ func init() {
 		"will unsafely write config if set")
 
 	rootCmd.AddCommand(confgenCmd)
+
 }
 
 var confgenCmd = &cobra.Command{
-	Use:    "confgen <config.json>",
-	Short:  "generates config file",
-	Args:   cobra.ExactArgs(1),
+	Use:   "confgen <config.json>",
+	Short: "generates config file",
+	// setting max arguments to 1 so that passing flag is optional
+	Args:   cobra.MaximumNArgs(1),
 	PreRun: prepareVariables,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if unsafe {
-			return viper.WriteConfigAs(args[0])
+
+		// if no arguments are passed
+		if len(args) == 0 {
+
+			// set confPath to default
+			confPath = "./config.json"
+
+			// generate seckey
+			if !skGen {
+				prepareSk()
+			}
+
+			// write conf to default file
+			if unsafe {
+				return viper.WriteConfigAs(confPath)
+			}
+			return viper.SafeWriteConfigAs(confPath)
+
+		} else {
+
+			if unsafe {
+				return viper.WriteConfigAs(args[0])
+			}
+			return viper.SafeWriteConfigAs(args[0])
 		}
-		return viper.SafeWriteConfigAs(args[0])
+
 	},
+}
+
+func prepareSk() {
+
+	pk, sk := cipher.GenerateKeyPair()
+	log.WithField("pubkey", pk).
+		WithField("seckey", sk).
+		Info("Generating key pair")
+	viper.Set("sk", sk)
 }

--- a/cmd/dmsgpty-host/commands/confgen.go
+++ b/cmd/dmsgpty-host/commands/confgen.go
@@ -1,6 +1,11 @@
 package commands
 
 import (
+<<<<<<< HEAD
+	"os"
+
+=======
+>>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -19,11 +24,39 @@ func init() {
 var confgenCmd = &cobra.Command{
 	Use:   "confgen <config.json>",
 	Short: "generates config file",
+<<<<<<< HEAD
+	// setting max arguments to 1 so that not an passing argument follows a default set of actions
+=======
 	// setting max arguments to 1 so that passing flag is optional
+>>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 	Args:   cobra.MaximumNArgs(1),
 	PreRun: prepareVariables,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
+<<<<<<< HEAD
+		if len(args) == 0 {
+			confPath = "./config.json"
+		} else {
+			confPath = args[0]
+		}
+
+		if _, err := os.Stat(confPath); err == nil {
+
+		} else if os.IsNotExist(err) {
+			// generate seckey for new conf
+			pk, sk := cipher.GenerateKeyPair()
+			log.WithField("pubkey", pk).
+				WithField("seckey", sk).
+				Info("Generating key pair")
+
+			viper.Set("sk", sk)
+		}
+
+		if unsafe {
+			return viper.WriteConfigAs(confPath)
+		}
+		return viper.SafeWriteConfigAs(confPath)
+=======
 		// if no arguments are passed
 		if len(args) == 0 {
 
@@ -48,6 +81,7 @@ var confgenCmd = &cobra.Command{
 			}
 			return viper.SafeWriteConfigAs(args[0])
 		}
+>>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 
 	},
 }

--- a/cmd/dmsgpty-host/commands/confgen.go
+++ b/cmd/dmsgpty-host/commands/confgen.go
@@ -1,11 +1,8 @@
 package commands
 
 import (
-<<<<<<< HEAD
 	"os"
 
-=======
->>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -24,16 +21,11 @@ func init() {
 var confgenCmd = &cobra.Command{
 	Use:   "confgen <config.json>",
 	Short: "generates config file",
-<<<<<<< HEAD
 	// setting max arguments to 1 so that not an passing argument follows a default set of actions
-=======
-	// setting max arguments to 1 so that passing flag is optional
->>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 	Args:   cobra.MaximumNArgs(1),
 	PreRun: prepareVariables,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-<<<<<<< HEAD
 		if len(args) == 0 {
 			confPath = "./config.json"
 		} else {
@@ -56,41 +48,6 @@ var confgenCmd = &cobra.Command{
 			return viper.WriteConfigAs(confPath)
 		}
 		return viper.SafeWriteConfigAs(confPath)
-=======
-		// if no arguments are passed
-		if len(args) == 0 {
-
-			// set confPath to default
-			confPath = "./config.json"
-
-			// generate seckey
-			if !skGen {
-				prepareSk()
-			}
-
-			// write conf to default file
-			if unsafe {
-				return viper.WriteConfigAs(confPath)
-			}
-			return viper.SafeWriteConfigAs(confPath)
-
-		} else {
-
-			if unsafe {
-				return viper.WriteConfigAs(args[0])
-			}
-			return viper.SafeWriteConfigAs(args[0])
-		}
->>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 
 	},
-}
-
-func prepareSk() {
-
-	pk, sk := cipher.GenerateKeyPair()
-	log.WithField("pubkey", pk).
-		WithField("seckey", sk).
-		Info("Generating key pair")
-	viper.Set("sk", sk)
 }

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -168,7 +168,6 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 	// report usage of deprecated or invalid flags
 	if skGen {
 		log.Info("--skgen is deprecated. sk is automatically created when a new conf is generated.")
-<<<<<<< HEAD
 	} else if !confStdin && confPath != "" && !sk.Null() {
 
 		log.Info("--sk is deprecated. sk should be set via config file (default \"./config.json\")")
@@ -177,18 +176,6 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 		cmdutil.CatchWithMsg("value 'seckey' is invalid", sk.Set(skStr))
 	} else if skGen && !sk.Null() {
 		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
-=======
-	} else if !sk.Null() {
-		log.Info("--sk is deprecated. sk should just be set via config file (default \"./config.json\")")
-	} else if skGen && !sk.Null() {
-		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
-	}
-
-	// Grab secret key (from 'sk' and 'skgen' flags).
-	if !skGen {
-		// function to generate secret key
-		prepareSk()
->>>>>>> 791525cca58af96c46a6bf00117d5a1b8d200d3c
 	}
 
 	// Grab secret key (from 'sk' and 'skgen' flags).

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -34,8 +34,8 @@ var (
 	// persistent flags (with viper references)
 	skDeprecated cipher.SecKey
 
-	sk           cipher.SecKey
-	wlPath       = ""
+	sk cipher.SecKey
+	//wlPath       = ""
 	dmsgDisc     = dmsg.DefaultDiscAddr
 	dmsgSessions = dmsg.DefaultMinSessions
 	dmsgPort     = dmsgpty.DefaultPort
@@ -61,8 +61,8 @@ func init() {
 	rootCmd.PersistentFlags().Var(&skDeprecated, "sk",
 		"secret key of the dmsgpty-host")
 
-	rootCmd.PersistentFlags().StringVar(&wlPath, "wl", wlPath,
-		"path of json whitelist file (if unspecified, a memory whitelist will be used)")
+	// rootCmd.PersistentFlags().StringVar(&wlPath, "wl", wlPath,
+	// 	"path of json whitelist file (if unspecified, a memory whitelist will be used)")
 
 	rootCmd.PersistentFlags().StringVar(&dmsgDisc, "dmsgdisc", dmsgDisc,
 		"dmsg discovery address")
@@ -187,7 +187,7 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 	// 	cmdutil.CatchWithMsg("value 'seckey' is invalid", sk.Set(skStr))
 	// }
 
-	wlPath = viper.GetString("wl")
+	//wlPath = viper.GetString("wl")
 	dmsgDisc = viper.GetString("dmsgdisc")
 	dmsgSessions = viper.GetInt("dmsgsessions")
 	dmsgPort = cast.ToUint16(viper.Get("dmsgport"))
@@ -237,13 +237,13 @@ var rootCmd = &cobra.Command{
 
 		// Prepare whitelist.
 		var wl dmsgpty.Whitelist
-		if wlPath == "" {
-			wl = dmsgpty.NewMemoryWhitelist()
-		} else {
-			var err error
-			wl, err = dmsgpty.NewJSONFileWhiteList(wlPath)
-			cmdutil.CatchWithLog(log, "failed to init whitelist", err)
-		}
+		// if wlPath == "" {
+		// 	wl = dmsgpty.NewMemoryWhitelist()
+		// } else {
+		// 	var err error
+		// 	wl, err = dmsgpty.NewJSONFileWhiteList(wlPath)
+		// 	cmdutil.CatchWithLog(log, "failed to init whitelist", err)
+		// }
 
 		// Prepare dmsgpty host.
 		host := dmsgpty.NewHost(dmsgC, wl)

--- a/const.go
+++ b/const.go
@@ -5,7 +5,7 @@ import "time"
 // Constants.
 const (
 	// TODO(evanlinjin): Reference the production address on release
-	DefaultDiscAddr = "dmsg.discovery.skywire.skycoin.com"
+	DefaultDiscAddr = "http://dmsg.discovery.skywire.skycoin.com"
 
 	DefaultMinSessions = 1
 

--- a/const.go
+++ b/const.go
@@ -5,7 +5,7 @@ import "time"
 // Constants.
 const (
 	// TODO(evanlinjin): Reference the production address on release
-	DefaultDiscAddr = "http://dmsg.discovery.skywire.cc"
+	DefaultDiscAddr = "dmsg.discovery.skywire.skycoin.com"
 
 	DefaultMinSessions = 1
 


### PR DESCRIPTION
Fixes #57 

 Changes:	
* `confpath` is shortened to `-c`
* `dmsgpty-host` defaults to production deployment `dmsg.discovery.skywire.skycoin.com`
* `dmsgpty-host confgen` generates the config file to `config.json` by default.
* A new `sk` is created, if a new conf is generated.
* `sk` is set via config file.