### PR TITLE
Improve dmsgpty

### DIFF
--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -80,21 +80,19 @@ func initConfig() {
 	// confPath := "./config.json"
 	err := checkFile(confPath)
 	if err != nil {
-		return
+		cli.Log.Fatalln("Default config file \"config.json\" not found.")
 	}
 
 	// read file using ioutil
 	file, err := ioutil.ReadFile(confPath)
 	if err != nil {
-		log.Println("unable to read config file :", confPath)
-		return
+		cli.Log.Fatalln("Unable to read ", confPath, err)
 	}
 
 	// store config.json into conf
 	err = json.Unmarshal(file, &conf)
 	if err != nil {
-		log.Println("unable to unmarshal config file properly:", confPath)
-		log.Println(err)
+		cli.Log.Errorln(err)
 		// ignoring this error
 	}
 
@@ -105,22 +103,20 @@ func initConfig() {
 		// marshal content
 		b, err := json.MarshalIndent(conf, "", "  ")
 		if err != nil {
-			log.Println("unable to marshal conf")
-			return
+			cli.Log.Fatalln("Unable to marshal conf")
 		}
 
 		// show changed config
-		_, err = os.Stdout.Write(b)
-		if err != nil {
-			log.Println("unable to write to stdout")
-			return
-		}
+		// _, err = os.Stdout.Write(b)
+		// if err != nil {
+		// 	cli.Log.Info("unable to write to stdout")
+
+		// }
 
 		// write to config.json
 		err = ioutil.WriteFile("config.json", b, 0600)
 		if err != nil {
-			log.Println("unable to write to config file")
-			return
+			cli.Log.Fatalln("Unable to write", confPath, err)
 		}
 	}
 }

--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -65,20 +65,26 @@ func init() {
 		"command arguments")
 
 	// check if "config.json" exists
-	filename := "config.json"
+	filename := "./config.json"
 	err := checkFile(filename)
 	if err != nil {
-		log.Fatalln(err)
+		return
 	}
 
 	// read file using ioutil
 	file, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println("unable to read config file :", filename)
+		return
 	}
 
 	// store config.json into conf
-	json.Unmarshal(file, &conf)
+	err = json.Unmarshal(file, &conf)
+	if err != nil {
+		log.Println("unable to unmarshal config file properly:", filename)
+		log.Println(err)
+		// ignoring this error
+	}
 
 	// check if config file is newly created
 	if conf.Wl == nil {
@@ -87,16 +93,22 @@ func init() {
 		// marshal content
 		b, err := json.MarshalIndent(conf, "", "  ")
 		if err != nil {
-			log.Fatalln(err)
+			log.Println("unable to marshal conf")
+			return
 		}
 
 		// show changed config
-		os.Stdout.Write(b)
+		_, err = os.Stdout.Write(b)
+		if err != nil {
+			log.Println("unable to write to stdout")
+			return
+		}
 
 		// write to config.json
-		err = ioutil.WriteFile("config.json", b, 0644)
+		err = ioutil.WriteFile("config.json", b, 0600)
 		if err != nil {
-			log.Fatalln(err)
+			log.Println("unable to write to config file")
+			return
 		}
 	}
 }

--- a/cmd/dmsgpty-cli/commands/whitelist.go
+++ b/cmd/dmsgpty-cli/commands/whitelist.go
@@ -161,7 +161,7 @@ func updateFile() error {
 	// }
 
 	// write to config file
-	err = ioutil.WriteFile("config.json", b, 0600)
+	err = ioutil.WriteFile(confPath, b, 0600)
 	if err != nil {
 		return err
 	}

--- a/cmd/dmsgpty-cli/commands/whitelist.go
+++ b/cmd/dmsgpty-cli/commands/whitelist.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
+	"log"
 
 	"github.com/spf13/cobra"
 
@@ -79,7 +79,11 @@ var whitelistAddCmd = &cobra.Command{
 		}
 
 		// write the changes back to the config file
-		updateFile()
+		err = updateFile()
+		if err != nil {
+			log.Println("unable to update config file")
+			return err
+		}
 
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
@@ -103,10 +107,10 @@ var whitelistRemoveCmd = &cobra.Command{
 		// for each pubkey to be removed
 		for _, k := range pks {
 
-			// find occurence of pubkey in config whitelist
+			// find occurrence of pubkey in config whitelist
 			for i := 0; i < len(conf.Wl); i++ {
 
-				// if an occurence is found
+				// if an occurrence is found
 				if k == conf.Wl[i] {
 					// remove element
 					conf.Wl = append(conf.Wl[:i], conf.Wl[i+1:]...)
@@ -116,7 +120,11 @@ var whitelistRemoveCmd = &cobra.Command{
 		}
 
 		// write changes back to the config file
-		updateFile()
+		err = updateFile()
+		if err != nil {
+			log.Println("unable to update config file")
+			return err
+		}
 
 		wlC, err := cli.WhitelistClient()
 		if err != nil {
@@ -146,10 +154,14 @@ func updateFile() error {
 	}
 
 	// (optionally) display changed config
-	os.Stdout.Write(b)
+	// _, err = os.Stdout.Write(b)
+	// if err != nil {
+	//	log.Println("unable to write to stdout")
+	//	return err
+	// }
 
 	// write to config file
-	err = ioutil.WriteFile("config.json", b, 0644)
+	err = ioutil.WriteFile("config.json", b, 0600)
 	if err != nil {
 		return err
 	}

--- a/cmd/dmsgpty-host/commands/confgen.go
+++ b/cmd/dmsgpty-host/commands/confgen.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"os"
+
+	"github.com/skycoin/dmsg/cipher"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -17,12 +20,33 @@ func init() {
 var confgenCmd = &cobra.Command{
 	Use:    "confgen <config.json>",
 	Short:  "generates config file",
-	Args:   cobra.ExactArgs(1),
+	Args:   cobra.MaximumNArgs(1),
 	PreRun: prepareVariables,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if unsafe {
-			return viper.WriteConfigAs(args[0])
+
+		if len(args) == 0 {
+			confPath = "./config.json"
+		} else {
+			confPath = args[0]
 		}
-		return viper.SafeWriteConfigAs(args[0])
+
+		if _, err := os.Stat(confPath); err == nil {
+
+			log.Info(confPath, " Already exists. Run 'dmsgpty-host --help' for usage.")
+
+		} else {
+
+			pk, sk := cipher.GenerateKeyPair()
+			log.WithField("pubkey", pk).
+				WithField("seckey", sk).
+				Info("Generating key pair")
+
+			viper.Set("sk", sk)
+		}
+
+		if unsafe {
+			return viper.WriteConfigAs(confPath)
+		}
+		return viper.SafeWriteConfigAs(confPath)
 	},
 }

--- a/cmd/dmsgpty-host/commands/confgen.go
+++ b/cmd/dmsgpty-host/commands/confgen.go
@@ -32,7 +32,7 @@ var confgenCmd = &cobra.Command{
 
 		if _, err := os.Stat(confPath); err == nil {
 
-			log.Info(confPath, "Already exists. Run 'dmsgpty-host --help' for usage.")
+			log.Fatalln(confPath, "Already exists. Run 'dmsgpty-host --help' for usage.")
 
 		} else {
 

--- a/cmd/dmsgpty-host/commands/confgen.go
+++ b/cmd/dmsgpty-host/commands/confgen.go
@@ -32,7 +32,7 @@ var confgenCmd = &cobra.Command{
 
 		if _, err := os.Stat(confPath); err == nil {
 
-			log.Info(confPath, " Already exists. Run 'dmsgpty-host --help' for usage.")
+			log.Info(confPath, "Already exists. Run 'dmsgpty-host --help' for usage.")
 
 		} else {
 

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -10,11 +10,9 @@ import (
 	"sync"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skycoin/src/util/logging"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/skycoin/dmsg"
@@ -174,17 +172,17 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 
 	} else if skGen && !sk.Null() {
 
-		log.Info("Values 'skgen' and 'sk' cannot be both set.")
+		log.Fatalln("Values 'skgen' and 'sk' cannot be both set.")
 	}
 
 	// Print values.
-	pLog := logrus.FieldLogger(log)
-	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-		if v := viper.Get(flag.Name); v != nil {
-			pLog = pLog.WithField(flag.Name, v)
-		}
-	})
-	pLog.Info("Init complete.")
+	// pLog := logrus.FieldLogger(log)
+	// cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+	// 	if v := viper.Get(flag.Name); v != nil {
+	// 		pLog = pLog.WithField(flag.Name, v)
+	// 	}
+	// })
+	// pLog.Info("Init complete.")
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -146,6 +146,8 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 				viper.SetConfigFile(confPath)
 				cmdutil.CatchWithMsg("Unable to read from (default \"config.json\")", viper.ReadInConfig())
 
+				cmdutil.CatchWithMsg("Unable to set sk", sk.Set(viper.GetString("sk")))
+
 			} else {
 				log.Info("No config files found. Run 'dmsgpty-host --help' for usage.")
 			}
@@ -153,7 +155,7 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 	}
 
 	// Grab final values of variables.
-	sk.Set(viper.GetString("sk"))
+
 	dmsgDisc = viper.GetString("dmsgdisc")
 	dmsgSessions = viper.GetInt("dmsgsessions")
 	dmsgPort = cast.ToUint16(viper.Get("dmsgport"))
@@ -172,7 +174,7 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 
 	} else if skGen && !sk.Null() {
 
-		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
+		log.Info("Values 'skgen' and 'sk' cannot be both set.")
 	}
 
 	// Print values.

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -146,12 +146,12 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 				viper.SetConfigFile(confPath)
 				cmdutil.CatchWithMsg("Unable to read from (default \"config.json\")", viper.ReadInConfig())
 
-				cmdutil.CatchWithMsg("Unable to set sk", sk.Set(viper.GetString("sk")))
-
 			} else {
 				log.Info("No config files found. Run 'dmsgpty-host --help' for usage.")
 			}
 		}
+
+		cmdutil.CatchWithMsg("Unable to set sk", sk.Set(viper.GetString("sk")))
 	}
 
 	// Grab final values of variables.

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -135,7 +135,7 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 				json.NewDecoder(os.Stdin).Decode(&v),
 				json.NewEncoder(buf).Encode(v),
 				viper.ReadConfig(buf))
-		} else if confPath != "config.json" {
+		} else if confPath != "./config.json" {
 			viper.SetConfigFile(confPath)
 			cmdutil.CatchWithMsg("flag 'confpath' is set, but we failed to read config from specified path",
 				viper.ReadInConfig())

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -35,7 +35,6 @@ var json = jsoniter.ConfigFastest
 var (
 	// persistent flags (with viper references)
 	sk           cipher.SecKey
-	wlPath       = ""
 	dmsgDisc     = dmsg.DefaultDiscAddr
 	dmsgSessions = dmsg.DefaultMinSessions
 	dmsgPort     = dmsgpty.DefaultPort
@@ -60,9 +59,6 @@ func init() {
 
 	rootCmd.PersistentFlags().Var(&sk, "sk",
 		"secret key of the dmsgpty-host")
-
-	rootCmd.PersistentFlags().StringVar(&wlPath, "wl", wlPath,
-		"path of json whitelist file (if unspecified, a memory whitelist will be used)")
 
 	rootCmd.PersistentFlags().StringVar(&dmsgDisc, "dmsgdisc", dmsgDisc,
 		"dmsg discovery address")
@@ -158,6 +154,11 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 
 	// Grab final values of variables.
 	sk.Set(viper.GetString("sk"))
+	dmsgDisc = viper.GetString("dmsgdisc")
+	dmsgSessions = viper.GetInt("dmsgsessions")
+	dmsgPort = cast.ToUint16(viper.Get("dmsgport"))
+	cliNet = viper.GetString("clinet")
+	cliAddr = viper.GetString("cliaddr")
 
 	// Report usage of deprecated or invalid flags
 
@@ -173,13 +174,6 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 
 		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
 	}
-
-	wlPath = viper.GetString("wl")
-	dmsgDisc = viper.GetString("dmsgdisc")
-	dmsgSessions = viper.GetInt("dmsgsessions")
-	dmsgPort = cast.ToUint16(viper.Get("dmsgport"))
-	cliNet = viper.GetString("clinet")
-	cliAddr = viper.GetString("cliaddr")
 
 	// Print values.
 	pLog := logrus.FieldLogger(log)
@@ -221,13 +215,13 @@ var rootCmd = &cobra.Command{
 
 		// Prepare whitelist.
 		var wl dmsgpty.Whitelist
-		if wlPath == "" {
-			wl = dmsgpty.NewMemoryWhitelist()
-		} else {
-			var err error
-			wl, err = dmsgpty.NewJSONFileWhiteList(wlPath)
-			cmdutil.CatchWithLog(log, "failed to init whitelist", err)
-		}
+		// if wlPath == "" {
+		// 	wl = dmsgpty.NewMemoryWhitelist()
+		// } else {
+		// 	var err error
+		// 	wl, err = dmsgpty.NewJSONFileWhiteList(wlPath)
+		// 	cmdutil.CatchWithLog(log, "failed to init whitelist", err)
+		// }
 
 		// Prepare dmsgpty host.
 		host := dmsgpty.NewHost(dmsgC, wl)

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -159,20 +159,20 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 	// Grab final values of variables.
 	sk.Set(viper.GetString("sk"))
 
-	// Grab secret key (from 'sk' and 'skgen' flags).
-	// if skGen {
-	// 	if !sk.Null() {
-	// 		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
-	// 	}
-	// 	var pk cipher.PubKey
-	// 	pk, sk = cipher.GenerateKeyPair()
-	// 	log.WithField("pubkey", pk).
-	// 		WithField("seckey", sk).
-	// 		Info("Generating key pair as 'skgen' is set.")
-	// 	viper.Set("sk", sk)
-	// }
-	// skStr := viper.GetString("sk")
-	// cmdutil.CatchWithMsg("value 'seckey' is invalid", sk.Set(skStr))
+	// Report usage of deprecated or invalid flags
+
+	if skGen {
+
+		log.Info("--skgen is deprecated. sk is automatically created when a new conf is generated.")
+
+	} else if !confStdin && confPath != "" && !sk.Null() {
+
+		log.Info("--sk is deprecated. sk is set via config file (default \"./config.json\")")
+
+	} else if skGen && !sk.Null() {
+
+		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
+	}
 
 	wlPath = viper.GetString("wl")
 	dmsgDisc = viper.GetString("dmsgdisc")

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -92,7 +92,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&confStdin, "confstdin", confStdin,
 		"config will be read from stdin if set")
 
-	rootCmd.Flags().StringVar(&confPath, "confpath", confPath,
+	rootCmd.Flags().StringVarP(&confPath, "confpath", "c", confPath,
 		"config path")
 }
 

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -157,21 +157,22 @@ func prepareVariables(cmd *cobra.Command, _ []string) {
 	}
 
 	// Grab final values of variables.
+	sk.Set(viper.GetString("sk"))
 
 	// Grab secret key (from 'sk' and 'skgen' flags).
-	if skGen {
-		if !sk.Null() {
-			log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
-		}
-		var pk cipher.PubKey
-		pk, sk = cipher.GenerateKeyPair()
-		log.WithField("pubkey", pk).
-			WithField("seckey", sk).
-			Info("Generating key pair as 'skgen' is set.")
-		viper.Set("sk", sk)
-	}
-	skStr := viper.GetString("sk")
-	cmdutil.CatchWithMsg("value 'seckey' is invalid", sk.Set(skStr))
+	// if skGen {
+	// 	if !sk.Null() {
+	// 		log.Fatal("Values 'skgen' and 'sk' cannot be both set.")
+	// 	}
+	// 	var pk cipher.PubKey
+	// 	pk, sk = cipher.GenerateKeyPair()
+	// 	log.WithField("pubkey", pk).
+	// 		WithField("seckey", sk).
+	// 		Info("Generating key pair as 'skgen' is set.")
+	// 	viper.Set("sk", sk)
+	// }
+	// skStr := viper.GetString("sk")
+	// cmdutil.CatchWithMsg("value 'seckey' is invalid", sk.Set(skStr))
 
 	wlPath = viper.GetString("wl")
 	dmsgDisc = viper.GetString("dmsgdisc")

--- a/const.go
+++ b/const.go
@@ -4,8 +4,7 @@ import "time"
 
 // Constants.
 const (
-	// TODO(evanlinjin): Reference the production address on release
-	DefaultDiscAddr = "http://dmsg.discovery.skywire.cc"
+	DefaultDiscAddr = "http://dmsg.discovery.skywire.skycoin.com"
 
 	DefaultMinSessions = 1
 


### PR DESCRIPTION
Fixes #57

Changes:

* default production deployment updated to http://dmsg.discovery.skywire.skycoin.com
* `dmsgpty-host` looks for config.json by default
* for new conf generation, sk is also generated and stored in config file
* sk is set via config file
* `--sk` and `--skgen` are deprecated / disabled
* `confpath` flag is shortened to `-c`
* removed `--wl` flag from `dmsgpty-host`
* whitelist is stored in config file
* `whitelist-add` adds pk to whitelist (config file)
* `whitelist-remove` removes pk to whitelist (config file)

