### PR TITLE
Cancellable Downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 .idea/
 bin/
+hello2/
 
 /dmsg-discovery
 /dmsg-server

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 
 .idea/
 bin/
-hello2/
 
 /dmsg-discovery
 /dmsg-server

--- a/dmsgget/dmsgget.go
+++ b/dmsgget/dmsgget.go
@@ -225,16 +225,16 @@ func Download(ctx context.Context, log logrus.FieldLogger, httpC *http.Client, w
 	if err != nil {
 		return fmt.Errorf("failed to connect to HTTP server: %w", err)
 	}
+	n, err := CancellableCopy(ctx, w, resp.Body, resp.ContentLength)
+	if err != nil {
+		return fmt.Errorf("download failed at %d/%dB: %w", n, resp.ContentLength, err)
+	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
 			log.WithError(err).Warn("HTTP Response body closed with non-nil error.")
 		}
 	}()
 
-	n, err := CancellableCopy(ctx, w, resp.Body, resp.ContentLength)
-	if err != nil {
-		return fmt.Errorf("download failed at %d/%dB: %w", n, resp.ContentLength, err)
-	}
 	return nil
 }
 

--- a/dmsgget/dmsgget.go
+++ b/dmsgget/dmsgget.go
@@ -119,7 +119,7 @@ func (dg *DmsgGet) Run(ctx context.Context, log logrus.FieldLogger, skStr string
 			return fmt.Errorf("failed to reset file: %w", err)
 		}
 
-		if err := Download(log, &httpC, file, u.URL.String()); err != nil {
+		if err := Download(ctx, log, &httpC, file, u.URL.String()); err != nil {
 			log.WithError(err).Error()
 			select {
 			case <-ctx.Done():
@@ -215,7 +215,7 @@ func (dg *DmsgGet) startDmsg(ctx context.Context, log logrus.FieldLogger, pk cip
 }
 
 // Download downloads a file from the given URL into 'w'.
-func Download(log logrus.FieldLogger, httpC *http.Client, w io.Writer, urlStr string) error {
+func Download(ctx context.Context, log logrus.FieldLogger, httpC *http.Client, w io.Writer, urlStr string) error {
 	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
 	if err != nil {
 		log.WithError(err).Fatal("Failed to formulate HTTP request.")
@@ -231,9 +231,34 @@ func Download(log logrus.FieldLogger, httpC *http.Client, w io.Writer, urlStr st
 		}
 	}()
 
-	n, err := io.Copy(io.MultiWriter(w, &ProgressWriter{Total: resp.ContentLength}), resp.Body)
+	n, err := CancellableCopy(ctx, w, resp.Body, resp.ContentLength)
 	if err != nil {
 		return fmt.Errorf("download failed at %d/%dB: %w", n, resp.ContentLength, err)
 	}
 	return nil
+}
+
+type readerFunc func(p []byte) (n int, err error)
+
+func (rf readerFunc) Read(p []byte) (n int, err error) { return rf(p) }
+
+// CancellableCopy will call the Reader and Writer interface multiple time, in order
+// to copy by chunk (avoiding loading the whole file in memory).
+func CancellableCopy(ctx context.Context, w io.Writer, body io.ReadCloser, length int64) (int64, error) {
+
+	n, err := io.Copy(io.MultiWriter(w, &ProgressWriter{Total: length}), readerFunc(func(p []byte) (int, error) {
+
+		// golang non-blocking channel: https://gobyexample.com/non-blocking-channel-operations
+		select {
+
+		// if context has been canceled
+		case <-ctx.Done():
+			// stop process and propagate "Download Canceled" error
+			return 0, errors.New("Download Canceled")
+		default:
+			// otherwise just run default io.Reader implementation
+			return body.Read(p)
+		}
+	}))
+	return n, err
 }

--- a/dmsgget/dmsgget_test.go
+++ b/dmsgget/dmsgget_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/cmdutil"
 	"github.com/skycoin/dmsg/disc"
 	"github.com/skycoin/dmsg/dmsghttp"
 )
@@ -63,7 +64,9 @@ func TestDownload(t *testing.T) {
 	for i := 0; i < dlClients; i++ {
 		func(i int) {
 			log := logging.MustGetLogger(fmt.Sprintf("dl_client_%d", i))
-			err := Download(log, newHTTPClient(t, dc), dsts[i], hsAddr)
+			ctx, cancel := cmdutil.SignalContext(context.Background(), log)
+			defer cancel()
+			err := Download(ctx, log, newHTTPClient(t, dc), dsts[i], hsAddr)
 
 			errs[i] <- err
 			close(errs[i])


### PR DESCRIPTION
Fixes #39

 Changes:	
-  Added a new functions ```readerFunc()``` and ```CancellableCopy()``` and a method ```Read()``` for the ```readerFunc()``` in ```dmsgget.go```
- Passed a new parameter ```ctx``` in ```Download()``` in ```dmsgget.go```
- added ```ctx, cancel``` and passed a new parameter ```ctx``` in ```Download()``` in ```dmsgget_test.go```

How to test this PR:

1. Run `make build`
2. Run `go run ./examples/dmsgget/gen-keys/gen-keys.go` to Generate public/private key pair 
3. Run `go run ./examples/dmsgget/dmsg-example-http-server/dmsg-example-http-server.go --dir /tmp/dmsghttp --sk private key / SK goes here` 
3. Run `./bin/dmsgget dmsg://public-key goes here:80/hello.txt`
4. Hit Ctrl+c