### PR TITLE
changed default to bash in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 .DEFAULT_GOAL := help
 .PHONY : check lint install-linters dep test build
 

--- a/integration/env.sh
+++ b/integration/env.sh
@@ -173,7 +173,7 @@ function init_dmsg() {
   func_print "Running ${DMSG_SRV2}..."
   tmux send-keys -t ${DMSG_SRV2} './bin/dmsg-server ./integration/configs/dmsgserver2.json' C-m
   catch_ec $?
-
+  sleep 1
   func_print "${DMSG} session started successfully."
   tmux select-window -t bash
 }


### PR DESCRIPTION
Fixes #66

 Changes:	
- added ```SHELL := /bin/bash``` to MAKEFILE 

How to test this PR:
1. Start a redis database on the default port
2. Run ```make start-db```
3. See result
