### PR TITLE
WIP: bring back in-memory dmsgpty whitelist function

### DIFF
--- a/dmsgpty/whitelist.go
+++ b/dmsgpty/whitelist.go
@@ -153,7 +153,8 @@ func (w *configWhitelist) Remove(pks ...cipher.PubKey) error {
 }
 
 func (w *configWhitelist) open() error {
-	if _, err := os.Stat(w.confPath); err != nil {
+	info, err := os.Stat(w.confPath)
+	if err != nil {
 		if os.IsNotExist(err) {
 			_, err := os.Create(w.confPath)
 			if err != nil {
@@ -162,6 +163,11 @@ func (w *configWhitelist) open() error {
 		}
 		return err
 	}
+
+	if info.Size() == 0 {
+		updateFile(w.confPath)
+	}
+
 	// read file using ioutil
 	file, err := ioutil.ReadFile(w.confPath)
 	if err != nil {

--- a/dmsgpty/whitelist.go
+++ b/dmsgpty/whitelist.go
@@ -154,6 +154,12 @@ func (w *configWhitelist) Remove(pks ...cipher.PubKey) error {
 
 func (w *configWhitelist) open() error {
 	if _, err := os.Stat(w.confPath); err != nil {
+		if os.IsNotExist(err) {
+			_, err := os.Create(w.confPath)
+			if err != nil {
+				return err
+			}
+		}
 		return err
 	}
 	// read file using ioutil


### PR DESCRIPTION
Part of #84 

 Changes:	
- Brings back the in-memory dmsgpty whitelist function

How to test this PR:
- checkout this PR
- in your local skywire repo directory, do `go mod edit -replace github.com/skycoin/dmsg=../dmsg`
- test it in the integration test environment