### PR TITLE
Increase default timeout of dmsg-discovery

### DIFF
--- a/cmd/dmsg-discovery/internal/store/storer.go
+++ b/cmd/dmsg-discovery/internal/store/storer.go
@@ -45,7 +45,7 @@ type Config struct {
 // Config defaults.
 const (
 	DefaultURL     = "redis://localhost:6379"
-	DefaultTimeout = time.Minute
+	DefaultTimeout = time.Minute * 3
 )
 
 // DefaultConfig returns a config with default values.


### PR DESCRIPTION
Fixes [#417](https://github.com/SkycoinPro/skywire-services/issues/417)	

 Changes:	
- Increased default timeout of `dmsg-discovery` store from 1 to 3 minutes.

How to test this PR:
