### PR TITLE
Release changes

### DIFF
--- a/cmd/dmsg-discovery/internal/store/storer.go
+++ b/cmd/dmsg-discovery/internal/store/storer.go
@@ -45,7 +45,7 @@ type Config struct {
 // Config defaults.
 const (
 	DefaultURL     = "redis://localhost:6379"
-	DefaultTimeout = time.Minute
+	DefaultTimeout = time.Minute * 3
 )
 
 // DefaultConfig returns a config with default values.

--- a/const.go
+++ b/const.go
@@ -4,12 +4,11 @@ import "time"
 
 // Constants.
 const (
-	// TODO(evanlinjin): Reference the production address on release
-	DefaultDiscAddr = "http://dmsg.discovery.skywire.cc"
+	DefaultDiscAddr = "http://dmsg.discovery.skywire.skycoin.com"
 
 	DefaultMinSessions = 1
 
-	DefaultUpdateInterval = time.Second * 15
+	DefaultUpdateInterval = time.Minute
 
 	DefaultMaxSessions = 100
 )

--- a/disc/client.go
+++ b/disc/client.go
@@ -57,8 +57,6 @@ func (c *httpClient) Entry(ctx context.Context, publicKey cipher.PubKey) (*Entry
 		return nil, err
 	}
 
-	addKeepAlive(req)
-
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
@@ -106,7 +104,6 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 		return err
 	}
 
-	addKeepAlive(req)
 	req.Header.Set("Content-Type", "application/json")
 
 	// Since v0.3.0 visors send ?timeout=true, before v0.3.0 do not.
@@ -190,7 +187,6 @@ func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	addKeepAlive(req)
 	req = req.WithContext(ctx)
 
 	resp, err := c.client.Do(req)
@@ -222,8 +218,4 @@ func (c *httpClient) AvailableServers(ctx context.Context) ([]*Entry, error) {
 	}
 
 	return entries, nil
-}
-
-func addKeepAlive(req *http.Request) {
-	req.Header.Add("Connection", "keep-alive")
 }


### PR DESCRIPTION
Fixes #	

 Changes:	
- dmsg client and server heartbeat updated to 60 seconds.
- Removed the keepalive header for connections to the dmsg.Discovery.
- Increased default timeout of dmsg-discovery store from 1 to 3 minutes.

How to test this PR:
