### PR TITLE
dmsg docker push fixes

### DIFF
--- a/docker/scripts/docker-push.sh
+++ b/docker/scripts/docker-push.sh
@@ -19,8 +19,9 @@ function docker_build() {
 function docker_push() {
   docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
   docker tag skycoinpro/dmsg-server:"$tag" skycoinpro/dmsg-server:"$tag"
-  docker tag skycoinpro/dmsg-discovery"$tag" skycoinpro/dmsg-discovery:"$tag"
+  docker tag skycoinpro/dmsg-discovery:"$tag" skycoinpro/dmsg-discovery:"$tag"
   docker image push skycoinpro/dmsg-server:"$tag"
+  docker image push skycoinpro/dmsg-discovery:"$tag"
 }
 
 while getopts ":t:pb" o; do


### PR DESCRIPTION
Fixes docker image for dmsg-server and dmsg-discovery aren't being pushed to dockerhub

 Changes:	
- Fixes docker push to dockerhub

How to test this PR:

- Tested manually via the provided script (`./docker/scripts/docker-push.sh -t test -p`) and the correct images are pushed to dockerhub right now, i.e.:

https://hub.docker.com/repository/docker/skycoinpro/dmsg-server

and

https://hub.docker.com/repository/docker/skycoinpro/dmsg-discovery