### PR TITLE
Remove dmsg client heartbeat

### DIFF
--- a/client.go
+++ b/client.go
@@ -231,7 +231,7 @@ func (ce *Client) Close() error {
 			ce.log.
 				WithError(dSes.Close()).
 				Info("Session closed.")
-			ce.delSession(context.Background(), dSes.RemotePK())
+			// ce.delSession(context.Background(), dSes.RemotePK())
 		}
 		ce.sessions = make(map[cipher.PubKey]*SessionCommon)
 		ce.sessionsMx.Unlock()

--- a/client.go
+++ b/client.go
@@ -238,7 +238,7 @@ func (ce *Client) Close() error {
 		ce.delSession(context.Background(), ce.pk)
 		ce.porter.CloseAll(ce.log)
 	})
-
+	ce.log.Info("All sessions closed.")
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -149,9 +149,6 @@ func (ce *Client) Serve(ctx context.Context) {
 		}
 	}(cancellabelCtx)
 
-	// Ensure we start updateClientEntryLoop once only.
-	updateEntryLoopOnce := new(sync.Once)
-
 	for {
 		if isClosed(ce.done) {
 			return
@@ -197,9 +194,6 @@ func (ce *Client) Serve(ctx context.Context) {
 				}
 				time.Sleep(serveWait)
 			}
-
-			// Only start the update entry loop once we have at least one session established.
-			updateEntryLoopOnce.Do(func() { go ce.updateClientEntryLoop(cancellabelCtx, ce.done) })
 		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -218,7 +218,7 @@ func (ce *Client) Close() error {
 	if ce == nil {
 		return nil
 	}
-
+	var err error
 	ce.once.Do(func() {
 		close(ce.done)
 
@@ -235,14 +235,10 @@ func (ce *Client) Close() error {
 		ce.sessions = make(map[cipher.PubKey]*SessionCommon)
 		ce.log.Info("All sessions closed.")
 		ce.sessionsMx.Unlock()
-
 		ce.porter.CloseAll(ce.log)
+		err = ce.EntityCommon.delClientEntry(context.Background())
 	})
-	err := ce.EntityCommon.delClientEntry(context.Background())
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Listen listens on a given dmsg port.

--- a/client.go
+++ b/client.go
@@ -238,6 +238,10 @@ func (ce *Client) Close() error {
 
 		ce.porter.CloseAll(ce.log)
 	})
+	err := ce.EntityCommon.delClientEntry(context.Background())
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -119,7 +119,7 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 
 	// Init callback: on delete session.
 	c.EntityCommon.delSessionCallback = func(ctx context.Context) error {
-		err := c.EntityCommon.updateClientEntry(ctx, c.done)
+		err := c.EntityCommon.delClientEntry(ctx, c.done)
 		return err
 	}
 
@@ -231,12 +231,11 @@ func (ce *Client) Close() error {
 			ce.log.
 				WithError(dSes.Close()).
 				Info("Session closed.")
-			// ce.delSession(context.Background(), dSes.RemotePK())
 		}
 		ce.sessions = make(map[cipher.PubKey]*SessionCommon)
 		ce.sessionsMx.Unlock()
-		ce.log.Info("All sessions closed.")
 
+		ce.delSession(context.Background(), ce.pk)
 		ce.porter.CloseAll(ce.log)
 	})
 

--- a/client.go
+++ b/client.go
@@ -119,7 +119,7 @@ func NewClient(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Conf
 
 	// Init callback: on delete session.
 	c.EntityCommon.delSessionCallback = func(ctx context.Context) error {
-		err := c.EntityCommon.delClientEntry(ctx, c.done)
+		err := c.EntityCommon.updateClientEntry(ctx, c.done)
 		return err
 	}
 
@@ -233,12 +233,11 @@ func (ce *Client) Close() error {
 				Info("Session closed.")
 		}
 		ce.sessions = make(map[cipher.PubKey]*SessionCommon)
+		ce.log.Info("All sessions closed.")
 		ce.sessionsMx.Unlock()
 
-		ce.delSession(context.Background(), ce.pk)
 		ce.porter.CloseAll(ce.log)
 	})
-	ce.log.Info("All sessions closed.")
 	return nil
 }
 

--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -148,6 +148,11 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 
 		entryTimeout := time.Duration(0) // no timeout
 
+		// Since v0.5.0 visors do not send ?timeout=true anymore so this is for older visors.
+		if timeout := r.URL.Query().Get("timeout"); timeout == "true" {
+			entryTimeout = store.DefaultTimeout
+		}
+
 		entry := new(disc.Entry)
 		if err := json.NewDecoder(r.Body).Decode(entry); err != nil {
 			a.handleError(w, r, disc.ErrUnexpected)

--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -80,6 +80,7 @@ func New(log logrus.FieldLogger, db store.Storer, m discmetrics.Metrics, testMod
 	r.Get("/dmsg-discovery/entry/{pk}", api.getEntry())
 	r.Post("/dmsg-discovery/entry/", api.setEntry())
 	r.Post("/dmsg-discovery/entry/{pk}", api.setEntry())
+	r.Delete("/dmsg-discovery/entry/{pk}", api.deleteEntry())
 	r.Get("/dmsg-discovery/available_servers", api.getAvailableServers())
 	r.Get("/dmsg-discovery/health", api.health())
 	r.Get("/health", api.serviceHealth)
@@ -208,6 +209,32 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 		}
 
 		a.writeJSON(w, r, http.StatusOK, disc.MsgEntryUpdated)
+	}
+}
+
+// deleteEntry deletes the entry associated with the given public key
+// URI: /dmsg-discovery/entry/[?timeout={true|false}]
+// Method: DELETE
+// Args:
+//	json serialized entry object
+func (a *API) deleteEntry() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		staticPK := cipher.PubKey{}
+		if err := staticPK.UnmarshalText([]byte(chi.URLParam(r, "pk"))); err != nil {
+			a.handleError(w, r, disc.ErrBadInput)
+			return
+		}
+
+		entry, err := a.db.Entry(r.Context(), staticPK)
+
+		// If we make sure that every error is handled then we can
+		// remove the if and make the entry return the switch default
+		if err != nil {
+			a.handleError(w, r, err)
+			return
+		}
+
+		a.writeJSON(w, r, http.StatusOK, entry)
 	}
 }
 

--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -147,10 +147,6 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 
 		entryTimeout := time.Duration(0) // no timeout
 
-		if timeout := r.URL.Query().Get("timeout"); timeout == "true" {
-			entryTimeout = store.DefaultTimeout
-		}
-
 		entry := new(disc.Entry)
 		if err := json.NewDecoder(r.Body).Decode(entry); err != nil {
 			a.handleError(w, r, disc.ErrUnexpected)

--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -84,6 +84,16 @@ func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry, timeout ti
 	return nil
 }
 
+// DelEntry implements Storer DelEntry method for redisdb database
+func (r *redisStore) DelEntry(ctx context.Context, staticPubKey cipher.PubKey) error {
+	err := r.client.Del(staticPubKey.Hex()).Err()
+	if err != nil {
+		log.WithError(err).WithField("pk", staticPubKey).Errorf("Failed to delete entry from redis")
+		return err
+	}
+	return nil
+}
+
 // AvailableServers implements Storer AvailableServers method for redisdb database
 func (r *redisStore) AvailableServers(ctx context.Context, maxCount int) ([]*disc.Entry, error) {
 	var entries []*disc.Entry

--- a/cmd/dmsg-discovery/internal/store/storer.go
+++ b/cmd/dmsg-discovery/internal/store/storer.go
@@ -28,6 +28,9 @@ type Storer interface {
 	// This is unsafe and does not check signature.
 	SetEntry(ctx context.Context, entry *disc.Entry, timeout time.Duration) error
 
+	// DelEntry delete's an entry.
+	DelEntry(ctx context.Context, staticPubKey cipher.PubKey) error
+
 	// AvailableServers discovers available dmsg servers.
 	AvailableServers(ctx context.Context, maxCount int) ([]*disc.Entry, error)
 

--- a/cmd/dmsg-discovery/internal/store/testing.go
+++ b/cmd/dmsg-discovery/internal/store/testing.go
@@ -24,6 +24,12 @@ func (ms *MockStore) setEntry(staticPubKey string, payload []byte) {
 	ms.m[staticPubKey] = payload
 }
 
+func (ms *MockStore) delEntry(staticPubKey string) {
+	ms.mLock.Lock()
+	defer ms.mLock.Unlock()
+	delete(ms.m, staticPubKey)
+}
+
 func (ms *MockStore) entry(staticPubkey string) ([]byte, bool) {
 	ms.mLock.RLock()
 	defer ms.mLock.RUnlock()
@@ -84,6 +90,12 @@ func (ms *MockStore) SetEntry(ctx context.Context, entry *disc.Entry, timeout ti
 		ms.setServer(entry.Static.Hex(), payload)
 	}
 
+	return nil
+}
+
+// DelEntry implements Storer DelEntry method for MockStore
+func (ms *MockStore) DelEntry(ctx context.Context, staticPubKey cipher.PubKey) error {
+	ms.delEntry(staticPubKey.Hex())
 	return nil
 }
 

--- a/disc/client.go
+++ b/disc/client.go
@@ -107,8 +107,6 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	// Since v0.3.0 visors send ?timeout=true, before v0.3.0 do not.
-	// Since v0.5.0 visors send do not send ?timeout=true anymore.
 	q := req.URL.Query()
 	req.URL.RawQuery = q.Encode()
 
@@ -146,7 +144,7 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 	return nil
 }
 
-// DelEntry creates a new Entry.
+// DelEntry deletes an Entry.
 func (c *httpClient) DelEntry(ctx context.Context, e *Entry) error {
 	endpoint := c.address + "/dmsg-discovery/entry"
 	log := log.WithField("endpoint", endpoint)

--- a/disc/client.go
+++ b/disc/client.go
@@ -107,8 +107,8 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 	req.Header.Set("Content-Type", "application/json")
 
 	// Since v0.3.0 visors send ?timeout=true, before v0.3.0 do not.
+	// Since v0.5.0 visors send do not send ?timeout=true anymore.
 	q := req.URL.Query()
-	q.Add("timeout", "true")
 	req.URL.RawQuery = q.Encode()
 
 	req = req.WithContext(ctx)

--- a/disc/client.go
+++ b/disc/client.go
@@ -148,7 +148,7 @@ func (c *httpClient) PostEntry(ctx context.Context, e *Entry) error {
 
 // DelEntry creates a new Entry.
 func (c *httpClient) DelEntry(ctx context.Context, e *Entry) error {
-	endpoint := c.address + "/dmsg-discovery/entry/"
+	endpoint := c.address + "/dmsg-discovery/entry"
 	log := log.WithField("endpoint", endpoint)
 
 	marshaledEntry, err := json.Marshal(e)

--- a/disc/http_message.go
+++ b/disc/http_message.go
@@ -9,6 +9,7 @@ import (
 var (
 	MsgEntrySet     = HTTPMessage{Code: http.StatusOK, Message: "wrote a new entry"}
 	MsgEntryUpdated = HTTPMessage{Code: http.StatusOK, Message: "wrote new entry iteration"}
+	MsgEntryDeleted = HTTPMessage{Code: http.StatusOK, Message: "deleted entry"}
 )
 
 // HTTPMessage represents a message to be returned as an http response

--- a/disc/testing.go
+++ b/disc/testing.go
@@ -94,8 +94,8 @@ func (m *mockClient) PostEntry(_ context.Context, entry *Entry) error {
 }
 
 // DelEntry returns the mock client static public key associated entry
-func (m *mockClient) DelEntry(_ context.Context, pk cipher.PubKey) error {
-	m.delEntry(pk)
+func (m *mockClient) DelEntry(_ context.Context, entry *Entry) error {
+	m.delEntry(entry.Static)
 	return nil
 }
 

--- a/disc/testing.go
+++ b/disc/testing.go
@@ -36,8 +36,8 @@ func (m *mockClient) entry(pk cipher.PubKey) (Entry, bool) {
 }
 
 func (m *mockClient) delEntry(pk cipher.PubKey) {
-	m.mx.RLock()
-	defer m.mx.RUnlock()
+	m.mx.Lock()
+	defer m.mx.Unlock()
 	delete(m.entries, pk)
 }
 

--- a/disc/testing.go
+++ b/disc/testing.go
@@ -35,6 +35,12 @@ func (m *mockClient) entry(pk cipher.PubKey) (Entry, bool) {
 	return e, ok
 }
 
+func (m *mockClient) delEntry(pk cipher.PubKey) {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+	delete(m.entries, pk)
+}
+
 func (m *mockClient) setEntry(entry Entry) {
 	m.mx.Lock()
 	defer m.mx.Unlock()
@@ -84,6 +90,12 @@ func (m *mockClient) PostEntry(_ context.Context, entry *Entry) error {
 	}
 
 	m.setEntry(*entry)
+	return nil
+}
+
+// DelEntry returns the mock client static public key associated entry
+func (m *mockClient) DelEntry(_ context.Context, pk cipher.PubKey) error {
+	m.delEntry(pk)
 	return nil
 }
 

--- a/dmsgpty/host.go
+++ b/dmsgpty/host.go
@@ -46,7 +46,7 @@ func (h *Host) ServeCLI(ctx context.Context, lis net.Listener) error {
 		_ = lis.Close() //nolint:errcheck
 	}()
 
-	log := logging.MustGetLogger("dmsgpty:cli-server")
+	log := logging.MustGetLogger("dmsg_pty:cli-server")
 
 	mux := cliEndpoints(h)
 
@@ -86,9 +86,11 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 		return err
 	}
 
+	log := logging.MustGetLogger("dmsg_pty")
+
 	go func() {
 		<-ctx.Done()
-		h.log().
+		log.
 			WithError(lis.Close()).
 			Info("Serve() ended.")
 	}()
@@ -96,7 +98,7 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 	for {
 		stream, err := lis.AcceptStream()
 		if err != nil {
-			log := h.log().WithError(err)
+			log := log.WithError(err)
 			if err, ok := err.(net.Error); ok && err.Temporary() {
 				log.Warn("Failed to accept dmsg.Stream with temporary error, continuing...")
 				continue
@@ -111,7 +113,7 @@ func (h *Host) ListenAndServe(ctx context.Context, port uint16) error {
 		}
 
 		rPK := stream.RawRemoteAddr().PK
-		log := h.log().WithField("remote_pk", rPK.String())
+		log := log.WithField("remote_pk", rPK.String())
 		log.Info("Processing dmsg.Stream...")
 
 		if !h.authorize(log, rPK) {

--- a/dmsgtest/env_test.go
+++ b/dmsgtest/env_test.go
@@ -56,7 +56,7 @@ func TestEnv(t *testing.T) {
 		require.Len(t, env.AllClients(), 0)
 	})
 
-	// Ensure client/server entries are available and timeout when expected.
+	// Ensure server entries are available and timeout when expected.
 	// - Start discovery with entry_timeout=1s and x servers and y clients with update_interval=250ms
 	// - Start as normal. Entries should show up in discovery, and stay there.
 	t.Run("discovery_entry_timeout", func(t *testing.T) {
@@ -65,7 +65,7 @@ func TestEnv(t *testing.T) {
 			entryTimeout   = time.Millisecond * 500
 		)
 
-		// Start env, discovery, server and client.
+		// Start env, discovery, server.
 		env := NewEnv(t, timeout)
 		defer env.Shutdown()
 
@@ -75,20 +75,13 @@ func TestEnv(t *testing.T) {
 		s, err := env.NewServer(updateInterval)
 		require.NoError(t, err)
 
-		c, err := env.NewClient(&dmsg.Config{UpdateInterval: updateInterval})
-		require.NoError(t, err)
-
-		// Ensure existence of client/server entries in given time interval.
+		// Ensure existence of server entries in given time interval.
 		done := time.After(entryTimeout * 3)
 	Loop:
 		for {
 			se, err := d.Entry(context.TODO(), s.LocalPK())
 			require.NoError(t, err)
 			require.NotNil(t, se.Server)
-
-			ce, err := d.Entry(context.TODO(), c.LocalPK())
-			require.NoError(t, err)
-			require.NotNil(t, ce.Client)
 
 			select {
 			case <-done:

--- a/entity_common.go
+++ b/entity_common.go
@@ -259,7 +259,7 @@ func (c *EntityCommon) delClientEntry(ctx context.Context, _ chan struct{}) (err
 
 	defer func() {
 		if err == nil {
-			c.log.WithField("entry", entry).Debug("Entry Deleted successfully.")
+			c.log.Debug("Entry Deleted successfully.")
 		}
 	}()
 

--- a/entity_common.go
+++ b/entity_common.go
@@ -250,7 +250,7 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	return c.dc.PutEntry(ctx, c.sk, entry)
 }
 
-func (c *EntityCommon) delClientEntry(ctx context.Context, _ chan struct{}) (err error) {
+func (c *EntityCommon) delClientEntry(ctx context.Context) (err error) {
 
 	entry, err := c.dc.Entry(ctx, c.pk)
 	if err != nil {

--- a/entity_common.go
+++ b/entity_common.go
@@ -30,8 +30,8 @@ type EntityCommon struct {
 
 	log logrus.FieldLogger
 
-	setSessionCallback func(ctx context.Context, sessionCount int) error
-	delSessionCallback func(ctx context.Context, sessionCount int) error
+	setSessionCallback func(ctx context.Context) error
+	delSessionCallback func(ctx context.Context) error
 }
 
 func (c *EntityCommon) init(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, log logrus.FieldLogger, updateInterval time.Duration) {
@@ -107,7 +107,7 @@ func (c *EntityCommon) setSession(ctx context.Context, dSes *SessionCommon) bool
 	c.sessions[dSes.RemotePK()] = dSes
 
 	if c.setSessionCallback != nil {
-		if err := c.setSessionCallback(ctx, len(c.sessions)); err != nil {
+		if err := c.setSessionCallback(ctx); err != nil {
 			c.log.
 				WithField("func", "EntityCommon.setSession").
 				WithError(err).
@@ -121,7 +121,7 @@ func (c *EntityCommon) delSession(ctx context.Context, pk cipher.PubKey) {
 	c.sessionsMx.Lock()
 	delete(c.sessions, pk)
 	if c.delSessionCallback != nil {
-		if err := c.delSessionCallback(ctx, len(c.sessions)); err != nil {
+		if err := c.delSessionCallback(ctx); err != nil {
 			c.log.
 				WithField("func", "EntityCommon.delSession").
 				WithError(err).

--- a/entity_common.go
+++ b/entity_common.go
@@ -237,14 +237,6 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 		return c.dc.PostEntry(ctx, entry)
 	}
 
-	// Whether the client's CURRENT delegated servers is the same as what would be advertised.
-	sameSrvPKs := cipher.SamePubKeys(srvPKs, entry.Client.DelegatedServers)
-
-	// No update is needed if delegated servers has no delta, and an entry update is not due.
-	if _, due := c.updateIsDue(); sameSrvPKs && !due {
-		return nil
-	}
-
 	entry.Client.DelegatedServers = srvPKs
 	c.log.WithField("entry", entry).Debug("Updating entry.")
 	return c.dc.PutEntry(ctx, c.sk, entry)

--- a/entity_common.go
+++ b/entity_common.go
@@ -250,6 +250,23 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	return c.dc.PutEntry(ctx, c.sk, entry)
 }
 
+func (c *EntityCommon) delClientEntry(ctx context.Context, _ chan struct{}) (err error) {
+
+	entry, err := c.dc.Entry(ctx, c.pk)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err == nil {
+			c.log.WithField("entry", entry).Debug("Entry Deleted successfully.")
+		}
+	}()
+
+	c.log.WithField("entry", entry).Debug("Deleting entry.")
+	return c.dc.DelEntry(ctx, entry)
+}
+
 func getServerEntry(ctx context.Context, dc disc.APIClient, srvPK cipher.PubKey) (*disc.Entry, error) {
 	entry, err := dc.Entry(ctx, srvPK)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -67,10 +67,10 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 	s.done = make(chan struct{})
 	s.addrDone = make(chan struct{})
 	s.maxSessions = conf.MaxSessions
-	s.setSessionCallback = func(ctx context.Context, sessionCount int) error {
+	s.setSessionCallback = func(ctx context.Context) error {
 		return s.updateServerEntry(ctx, s.AdvertisedAddr(), s.maxSessions)
 	}
-	s.delSessionCallback = func(ctx context.Context, sessionCount int) error {
+	s.delSessionCallback = func(ctx context.Context) error {
 		return s.updateServerEntry(ctx, s.AdvertisedAddr(), s.maxSessions)
 	}
 	return s


### PR DESCRIPTION
Fixes #109 

 Changes:	
- Removed timeout from PostEntry
- Added `DELETE /dmsg-discovery/entry` endpoint
- Added DelEntry in client
- Removed updateClientEntryLoop
- Update dmsg pty logs to match skywire modules e.g.

before
```sh
[2021-09-10T16:50:44+05:30] INFO [dmsgpty:cli-server]: Cleanly stopped serving.
[2021-09-10T16:50:44+05:30] INFO [dmsgC]: Serve() ended. dmsgpty="host" error=<nil>
[2021-09-10T16:50:44+05:30] INFO [dmsgC]: Cleanly stopped serving. dmsgpty="host" error="dmsg error 200 - local entity closed"
```
after
```sh
[2021-09-10T15:43:55+05:30] INFO [dmsg_pty:cli-server]: Cleanly stopped serving.
[2021-09-10T15:43:55+05:30] INFO [dmsg_pty]: Serve() ended. error=<nil>
[2021-09-10T15:43:55+05:30] INFO [dmsg_pty]: Cleanly stopped serving. error="dmsg error 200 - local entity closed"
```

How to test this PR:
- Instructions given [here](https://github.com/skycoin/skywire/pull/883).
