### PR TITLE
Fix httpPort

### DIFF
--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -121,7 +121,7 @@ type Config struct {
 	Discovery      string        `json:"discovery"`
 	LocalAddress   string        `json:"local_address"`
 	PublicAddress  string        `json:"public_address"`
-	HTTPAddress    string        `json:"health_endpoint_address,omitempty"` // defaults to 8082
+	HTTPAddress    string        `json:"health_endpoint_address,omitempty"` // defaults to :8082
 	MaxSessions    int           `json:"max_sessions"`
 	UpdateInterval time.Duration `json:"update_interval"`
 	LogLevel       string        `json:"log_level"`
@@ -134,7 +134,7 @@ func genDefaultConfig() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpPort := hP + 1
+	httpPort := fmt.Sprintf(":%d", hP+1)
 
 	cfg := Config{
 		PubKey:        pk,
@@ -142,7 +142,7 @@ func genDefaultConfig() (io.ReadCloser, error) {
 		Discovery:     defaultDiscoveryURL,
 		LocalAddress:  fmt.Sprintf("localhost%s", defaultPort),
 		PublicAddress: defaultPort,
-		HTTPAddress:   fmt.Sprintf("localhost%d", httpPort),
+		HTTPAddress:   fmt.Sprintf("localhost%s", httpPort),
 		MaxSessions:   2048,
 		LogLevel:      "info",
 	}

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	defaultDiscoveryURL = "https://dmsg.discovery.skywire.skycoin.com"
+	defaultDiscoveryURL = "http://dmsgd.skywire.skycoin.com"
 	defaultPort         = ":8081"
 	defaultConfigPath   = "config.json"
 )


### PR DESCRIPTION
Fixes #116 

 Changes:	
- Fixed `httpPort` where it adds colon before the port.
- Updated the `defaultDiscoveryURL` url

How to test this PR:
1. deploy dmsg without giving config