### PR TITLE
fix server metric bug

### DIFF
--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -169,7 +169,7 @@ func (r *redisStore) RemoveOldServerEntries(ctx context.Context) error {
 	}
 	for _, server := range servers {
 		if r.client.Exists(server).Val() == 0 {
-			r.client.SRem(server)
+			r.client.SRem("servers", server)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #131

 Changes:	
- Fix remove entries from set record on servers.

How to test this PR:
- run integration by [this](https://github.com/skycoin/dmsg/tree/master/integration) instruction.
- kill dmsg-server process by `-9` flag
- check redis after two mintures by `redis-cli smember servers`. No record should left there.