### PR TITLE
Serving on dmsg-servers dynamically 

### DIFF
--- a/client.go
+++ b/client.go
@@ -181,7 +181,7 @@ func (ce *Client) Serve(ctx context.Context) {
 				}
 			}
 
-			if err := ce.ensureSession(cancellabelCtx, entry); err != nil {
+			if err := ce.EnsureSession(cancellabelCtx, entry); err != nil {
 				ce.log.WithField("remote_pk", entry.Static).WithError(err).Warn("Failed to establish session.")
 				if err == context.Canceled || err == context.DeadlineExceeded {
 					return
@@ -331,9 +331,9 @@ func (ce *Client) EnsureAndObtainSession(ctx context.Context, srvPK cipher.PubKe
 	return ce.dialSession(ctx, srvEntry)
 }
 
-// ensureSession ensures the existence of a session.
+// EnsureSession ensures the existence of a session.
 // It returns an error if the session does not exist AND cannot be established.
-func (ce *Client) ensureSession(ctx context.Context, entry *disc.Entry) error {
+func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 	ce.sesMx.Lock()
 	defer ce.sesMx.Unlock()
 

--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -192,10 +192,10 @@ func listenAndServe(addr string, handler http.Handler) error {
 		addr = ":http"
 	}
 	ln, err := net.Listen("tcp", addr)
-	proxyListener := &proxyproto.Listener{Listener: ln}
-	defer proxyListener.Close() // nolint:errcheck
 	if err != nil {
 		return err
 	}
+	proxyListener := &proxyproto.Listener{Listener: ln}
+	defer proxyListener.Close() // nolint:errcheck
 	return srv.Serve(proxyListener)
 }

--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -151,7 +151,7 @@ func getServers(ctx context.Context, a *api.API, log logrus.FieldLogger) (server
 	}
 }
 
-func updateServers(ctx context.Context, a *api.API, dClient direct.APIClient, log logrus.FieldLogger) {
+func updateServers(ctx context.Context, a *api.API, dClient disc.APIClient, log logrus.FieldLogger) {
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
 	for {

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -93,7 +93,7 @@ var RootCmd = &cobra.Command{
 			MaxSessions:    conf.MaxSessions,
 			UpdateInterval: conf.UpdateInterval,
 		}
-		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, disc.NewHTTP(conf.Discovery, &http.Client{}, nil), &srvConf, m)
+		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, disc.NewHTTP(conf.Discovery, &http.Client{}, log), &srvConf, m)
 		srv.SetLogger(log)
 
 		api.SetDmsgServer(srv)

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -290,7 +290,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		// Prepare and serve dmsg client and wait until ready.
-		dmsgC := dmsg.NewClient(pk, sk, disc.NewHTTP(conf.DmsgDisc, &http.Client{}, nil), &dmsg.Config{
+		dmsgC := dmsg.NewClient(pk, sk, disc.NewHTTP(conf.DmsgDisc, &http.Client{}, log), &dmsg.Config{
 			MinSessions: conf.DmsgSessions,
 		})
 		go dmsgC.Serve(context.Background())

--- a/direct/client.go
+++ b/direct/client.go
@@ -12,15 +12,6 @@ import (
 
 var log = logging.MustGetLogger("direct")
 
-// APIClient implements dmsg discovery API client.
-type APIClient interface {
-	Entry(context.Context, cipher.PubKey) (*disc.Entry, error)
-	PostEntry(context.Context, *disc.Entry) error
-	PutEntry(context.Context, cipher.SecKey, *disc.Entry) error
-	DelEntry(context.Context, *disc.Entry) error
-	AvailableServers(context.Context) ([]*disc.Entry, error)
-}
-
 // directClient represents a client that doesnot communicates with a dmsg-discovery, instead directly gets the dmsg-server info via the user or is hardcoded, it
 // implements APIClient
 type directClient struct {
@@ -29,7 +20,7 @@ type directClient struct {
 }
 
 // NewDirectClient constructs a new APIClient that communicates with discovery via http.
-func NewDirectClient(entries []*disc.Entry) APIClient {
+func NewDirectClient(entries []*disc.Entry) disc.APIClient {
 	entriesMap := make(map[cipher.PubKey]*disc.Entry)
 	for _, entry := range entries {
 		entriesMap[entry.Static] = entry

--- a/direct/direct.go
+++ b/direct/direct.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
+	"github.com/skycoin/dmsg/disc"
 )
 
 // StartDmsg starts dmsg directly without the discovery
 func StartDmsg(ctx context.Context, log logrus.FieldLogger, pk cipher.PubKey, sk cipher.SecKey,
-	dClient APIClient, config *dmsg.Config) (dmsgC *dmsg.Client, stop func(), err error) {
+	dClient disc.APIClient, config *dmsg.Config) (dmsgC *dmsg.Client, stop func(), err error) {
 
 	dmsgC = dmsg.NewClient(pk, sk, dClient, config)
 	go dmsgC.Serve(context.Background())

--- a/dmsgget/dmsgget.go
+++ b/dmsgget/dmsgget.go
@@ -69,7 +69,7 @@ func (dg *DmsgGet) flagGroups() []FlagGroup {
 }
 
 // Run runs the download logic.
-func (dg *DmsgGet) Run(ctx context.Context, log logrus.FieldLogger, skStr string, args []string) (err error) {
+func (dg *DmsgGet) Run(ctx context.Context, log *logging.Logger, skStr string, args []string) (err error) {
 	if log == nil {
 		log = logging.MustGetLogger("dmsgget")
 	}
@@ -191,8 +191,8 @@ func parseOutputFile(name string, urlPath string) (*os.File, error) {
 	return nil, os.ErrExist
 }
 
-func (dg *DmsgGet) startDmsg(ctx context.Context, log logrus.FieldLogger, pk cipher.PubKey, sk cipher.SecKey) (dmsgC *dmsg.Client, stop func(), err error) {
-	dmsgC = dmsg.NewClient(pk, sk, disc.NewHTTP(dg.dmsgF.Disc, &http.Client{}, nil), &dmsg.Config{MinSessions: dg.dmsgF.Sessions})
+func (dg *DmsgGet) startDmsg(ctx context.Context, log *logging.Logger, pk cipher.PubKey, sk cipher.SecKey) (dmsgC *dmsg.Client, stop func(), err error) {
+	dmsgC = dmsg.NewClient(pk, sk, disc.NewHTTP(dg.dmsgF.Disc, &http.Client{}, log), &dmsg.Config{MinSessions: dg.dmsgF.Sessions})
 	go dmsgC.Serve(context.Background())
 
 	stop = func() {

--- a/dmsghttp/http.go
+++ b/dmsghttp/http.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
-	"github.com/skycoin/dmsg/direct"
 	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -15,12 +14,7 @@ import (
 
 // ListenAndServe serves http over dmsg
 func ListenAndServe(ctx context.Context, pk cipher.PubKey, sk cipher.SecKey, a http.Handler, dClient disc.APIClient, dmsgPort uint16,
-	config *dmsg.Config, log *logging.Logger) error {
-	dmsgC, closeDmsg, err := direct.StartDmsg(ctx, log, pk, sk, dClient, config)
-	if err != nil {
-		return fmt.Errorf("failed to start dmsg: %w", err)
-	}
-	defer closeDmsg()
+	config *dmsg.Config, dmsgC *dmsg.Client, log *logging.Logger) error {
 
 	lis, err := dmsgC.Listen(dmsgPort)
 	if err != nil {

--- a/dmsghttp/http.go
+++ b/dmsghttp/http.go
@@ -8,12 +8,13 @@ import (
 	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/cipher"
 	"github.com/skycoin/dmsg/direct"
+	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
 )
 
 // ListenAndServe serves http over dmsg
-func ListenAndServe(ctx context.Context, pk cipher.PubKey, sk cipher.SecKey, a http.Handler, dClient direct.APIClient, dmsgPort uint16,
+func ListenAndServe(ctx context.Context, pk cipher.PubKey, sk cipher.SecKey, a http.Handler, dClient disc.APIClient, dmsgPort uint16,
 	config *dmsg.Config, log *logging.Logger) error {
 	dmsgC, closeDmsg, err := direct.StartDmsg(ctx, log, pk, sk, dClient, config)
 	if err != nil {

--- a/dmsghttp/util.go
+++ b/dmsghttp/util.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/skycoin/dmsg/direct"
 	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -35,7 +34,7 @@ func GetServers(ctx context.Context, dmsgDisc string, log *logging.Logger) (entr
 }
 
 // UpdateServers is used to update the servers in the direct client.
-func UpdateServers(ctx context.Context, dClient direct.APIClient, dmsgDisc string, log *logging.Logger) (entries []*disc.Entry) {
+func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string, log *logging.Logger) (entries []*disc.Entry) {
 	dmsgclient := disc.NewHTTP(dmsgDisc, http.Client{})
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()

--- a/dmsghttp/util.go
+++ b/dmsghttp/util.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/skycoin/dmsg"
 	"github.com/skycoin/dmsg/disc"
 
 	"github.com/skycoin/skycoin/src/util/logging"
@@ -34,7 +35,7 @@ func GetServers(ctx context.Context, dmsgDisc string, log *logging.Logger) (entr
 }
 
 // UpdateServers is used to update the servers in the direct client.
-func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string, log *logging.Logger) (entries []*disc.Entry) {
+func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string, dmsgC *dmsg.Client, log *logging.Logger) (entries []*disc.Entry) {
 	dmsgclient := disc.NewHTTP(dmsgDisc, http.Client{})
 	ticker := time.NewTicker(time.Second * 10)
 	defer ticker.Stop()
@@ -49,7 +50,8 @@ func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string,
 				break
 			}
 			for _, server := range servers {
-				dClient.PostEntry(ctx, server) //nolint
+				dClient.PostEntry(ctx, server)   //nolint
+				dmsgC.EnsureSession(ctx, server) //nolint
 			}
 		}
 	}

--- a/examples/dmsgget/dmsg-example-http-server/dmsg-example-http-server.go
+++ b/examples/dmsgget/dmsg-example-http-server/dmsg-example-http-server.go
@@ -44,7 +44,7 @@ func main() {
 		log.WithError(err).Fatal("Invalid CLI args.")
 	}
 
-	c := dmsg.NewClient(pk, sk, disc.NewHTTP(dmsgDisc, &http.Client{}, nil), dmsg.DefaultConfig())
+	c := dmsg.NewClient(pk, sk, disc.NewHTTP(dmsgDisc, &http.Client{}, log), dmsg.DefaultConfig())
 	defer func() {
 		if err := c.Close(); err != nil {
 			log.WithError(err).Error()


### PR DESCRIPTION
Fixes #133

 Changes:	
- Made `EnsureSession` public
- Removed `APIClient` from direct and sued `APIClient` from disc
- Added dynamic serving to`dmsghttp` via`dmsg direct`
- Removed `sk` requirement

How to test:
Given in [#skywire-services-500](https://github.com/SkycoinPro/skywire-services/pull/500)