### PR TITLE
Add extra logs for debugging in dmsghttp

### DIFF
--- a/client.go
+++ b/client.go
@@ -339,6 +339,7 @@ func (ce *Client) EnsureSession(ctx context.Context, entry *disc.Entry) error {
 
 	// If session with server of pk already exists, skip.
 	if _, ok := ce.clientSession(ce.porter, entry.Static); ok {
+		ce.log.WithField("remote_pk", entry.Static).Info("Session already exists...")
 		return nil
 	}
 

--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -171,8 +171,11 @@ func updateServers(ctx context.Context, a *api.API, dClient disc.APIClient, dmsg
 				break
 			}
 			for _, server := range servers {
-				dClient.PostEntry(ctx, server)   //nolint
-				dmsgC.EnsureSession(ctx, server) //nolint
+				dClient.PostEntry(ctx, server) //nolint
+				err := dmsgC.EnsureSession(ctx, server)
+				if err != nil {
+					log.WithField("remote_pk", server.Static).WithError(err).Warn("Failed to establish session.")
+				}
 			}
 		}
 	}

--- a/cmd/dmsg-discovery/commands/root.go
+++ b/cmd/dmsg-discovery/commands/root.go
@@ -158,7 +158,7 @@ func getServers(ctx context.Context, a *api.API, log logrus.FieldLogger) (server
 }
 
 func updateServers(ctx context.Context, a *api.API, dClient disc.APIClient, dmsgC *dmsg.Client, log logrus.FieldLogger) {
-	ticker := time.NewTicker(time.Second * 10)
+	ticker := time.NewTicker(time.Minute * 10)
 	defer ticker.Stop()
 	for {
 		select {

--- a/dmsghttp/util.go
+++ b/dmsghttp/util.go
@@ -37,7 +37,7 @@ func GetServers(ctx context.Context, dmsgDisc string, log *logging.Logger) (entr
 // UpdateServers is used to update the servers in the direct client.
 func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string, dmsgC *dmsg.Client, log *logging.Logger) (entries []*disc.Entry) {
 	dmsgclient := disc.NewHTTP(dmsgDisc, &http.Client{}, log)
-	ticker := time.NewTicker(time.Second * 10)
+	ticker := time.NewTicker(time.Minute * 10)
 	defer ticker.Stop()
 	for {
 		select {

--- a/dmsghttp/util.go
+++ b/dmsghttp/util.go
@@ -49,9 +49,13 @@ func UpdateServers(ctx context.Context, dClient disc.APIClient, dmsgDisc string,
 				log.WithError(err).Error("Error getting dmsg-servers.")
 				break
 			}
+			log.Infof("Servers found : %v.", len(servers))
 			for _, server := range servers {
-				dClient.PostEntry(ctx, server)   //nolint
-				dmsgC.EnsureSession(ctx, server) //nolint
+				dClient.PostEntry(ctx, server) //nolint
+				err := dmsgC.EnsureSession(ctx, server)
+				if err != nil {
+					log.WithField("remote_pk", server.Static).WithError(err).Warn("Failed to establish session.")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #	

 Changes:	
- Added logs for debugging
- Update the ticker time of funcs `updateServers()` and `UpdateServers()` from 10 secs to 10 mins

How to test this PR:
