### PR TITLE
Add StreamCloser

### DIFF
--- a/dmsgget/dmsgget_test.go
+++ b/dmsgget/dmsgget_test.go
@@ -66,7 +66,7 @@ func TestDownload(t *testing.T) {
 			log := logging.MustGetLogger(fmt.Sprintf("dl_client_%d", i))
 			ctx, cancel := cmdutil.SignalContext(context.Background(), log)
 			defer cancel()
-			err := Download(ctx, log, newHTTPClient(t, dc), dsts[i], hsAddr)
+			err := Download(ctx, log, newHTTPClient(t, dc), dsts[i], hsAddr, &dmsghttp.StreamCloser{})
 
 			errs[i] <- err
 			close(errs[i])
@@ -172,5 +172,6 @@ func newHTTPClient(t *testing.T, dc disc.APIClient) *http.Client {
 	t.Cleanup(func() { assert.NoError(t, dmsgC.Close()) })
 	<-dmsgC.Ready()
 
-	return &http.Client{Transport: dmsghttp.MakeHTTPTransport(dmsgC)}
+	test := make(chan map[*http.Request]uint32)
+	return &http.Client{Transport: dmsghttp.MakeHTTPTransport(dmsgC, test)}
 }

--- a/dmsghttp/examples_test.go
+++ b/dmsghttp/examples_test.go
@@ -86,9 +86,10 @@ func ExampleMakeHTTPTransport() {
 	}()
 	go dmsgC2.Serve(context.Background())
 	<-dmsgC2.Ready()
+	test := make(chan map[*http.Request]uint32)
 
 	// Run HTTP client.
-	httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(dmsgC2)}
+	httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(dmsgC2, test)}
 	resp, err := httpC.Get(fmt.Sprintf("http://%s:%d/", c1PK.String(), dmsgHTTPPort))
 	if err != nil {
 		panic(err)

--- a/dmsghttp/http_transport_test.go
+++ b/dmsghttp/http_transport_test.go
@@ -62,11 +62,12 @@ func TestHTTPTransport_RoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		startHTTPServer(t, server0Results, lis)
 		addr := lis.Addr().String()
+		test := make(chan map[*http.Request]uint32)
 
 		// Arrange: create http clients (in which each http client has an underlying dmsg client).
-		httpC1 := http.Client{Transport: MakeHTTPTransport(newDmsgClient(t, dc, minSessions, "client1"))}
-		httpC2 := http.Client{Transport: MakeHTTPTransport(newDmsgClient(t, dc, minSessions, "client2"))}
-		httpC3 := http.Client{Transport: MakeHTTPTransport(newDmsgClient(t, dc, minSessions, "client3"))}
+		httpC1 := http.Client{Transport: MakeHTTPTransport(newDmsgClient(t, dc, minSessions, "client1"), test)}
+		httpC2 := http.Client{Transport: MakeHTTPTransport(newDmsgClient(t, dc, minSessions, "client2"), test)}
+		httpC3 := http.Client{Transport: MakeHTTPTransport(newDmsgClient(t, dc, minSessions, "client3"), test)}
 		httpC1.Timeout = timeout
 		httpC2.Timeout = timeout
 		httpC3.Timeout = timeout

--- a/dmsghttp/stream.go
+++ b/dmsghttp/stream.go
@@ -1,0 +1,57 @@
+package dmsghttp
+
+import (
+	"context"
+	"net/http"
+	"sync"
+
+	"github.com/skycoin/dmsg"
+)
+
+// StreamCloser saves a map
+type StreamCloser struct {
+	streamMap map[*http.Request]uint32
+	dmsgC     *dmsg.Client
+	mu        sync.Mutex
+}
+
+// NewStreamCloser gives a new stream closer
+func NewStreamCloser(dmsgC *dmsg.Client) *StreamCloser {
+	sMap := make(map[*http.Request]uint32)
+
+	sCloser := &StreamCloser{
+		streamMap: sMap,
+		dmsgC:     dmsgC,
+	}
+	return sCloser
+}
+
+// CloseStream closes the stream associated with the http req
+func (sc *StreamCloser) CloseStream(req *http.Request) error {
+	sc.mu.Lock()
+	streamID := sc.streamMap[req]
+	sc.mu.Unlock()
+	streams := sc.dmsgC.AllStreams()
+	for _, stream := range streams {
+		if streamID == stream.StreamID() {
+			if err := stream.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// GetMap gets the http request and the stream ID associated it with and save it
+func (sc *StreamCloser) GetMap(ctx context.Context, sMap chan map[*http.Request]uint32) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case streamMap := <-sMap:
+			sc.mu.Lock()
+			sc.streamMap = streamMap
+			sc.mu.Unlock()
+		}
+	}
+}


### PR DESCRIPTION
This commit adds StreamCloser which is used to save map of a http request against stream ID via a channel. It is also used to stop a session that is associated with a http request.

Fixes #	

 Changes:	
-	

How to test this PR:
