### PR TITLE
Fix outdated timestamp error

### DIFF
--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -240,6 +240,11 @@ func (a *API) delEntry() func(w http.ResponseWriter, r *http.Request) {
 		}
 
 		validateTimestamp := !a.enableLoadTesting
+		// we donot validate timestamp when entry is a client as the client no longer updates itself
+		// periodically and so the timestamp is never updated
+		if entry.Client != nil {
+			validateTimestamp = false
+		}
 		if err := entry.Validate(validateTimestamp); err != nil {
 			a.handleError(w, r, err)
 			return


### PR DESCRIPTION
Fixes #145 

 Changes:	
- Fixed `validateTimestamp` in `delEntry()`

How to test this PR:
1. In `skywire-service`  uncomment `//replace github.com/skycoin/dmsg => ../dmsg` in `go.mod` and run `make dep`
2. Start [Integration env](https://github.com/SkycoinPro/skywire-services/blob/develop/docs/InteractiveEnvironments.md)
3. After a minute shut down one of the visors with `Ctrl+C`
4. See if the error is seen again or not