### PR TITLE
Sort output of AvailableServers() in descending order

### DIFF
--- a/cmd/dmsg-discovery/internal/store/redis.go
+++ b/cmd/dmsg-discovery/internal/store/redis.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -143,6 +144,10 @@ func (r *redisStore) AvailableServers(ctx context.Context, maxCount int) ([]*dis
 
 		entries = append(entries, entry)
 	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Server.AvailableSessions > entries[j].Server.AvailableSessions
+	})
 
 	return entries, nil
 }


### PR DESCRIPTION
Fixes [#skywire-1082](https://github.com/skycoin/skywire/issues/1082)

 Changes:	
- Sorts the slice of entries in the func AvailableServers() in descending order

How to test this PR:
1. Build services `make build`
2. Run redis `docker run --rm --name=host-redis -p 6379:6379 redis`
3. Run dmsg-discovery `./bin/dmsg-discovery -t`
4. Run dmsg-server 1 `./bin/dmsg-discovery config.json`
    ```json
    {
        "public_key": "03f0db21cd864c35c3c555dfbcfc32c2f4a287d8e234dee5337177f3d5ee989cfc",
        "secret_key": "b63aa15f368f08b0ef87686cc49e9f9efa9ff67df94de84c09e123bd19219005",
        "local_address": "localhost:8071",
        "discovery": "http://localhost:9090",
        "public_address": ":8071",
        "health_endpoint_address": "localhost:8072",
        "max_sessions": 100,
        "update_interval": 0,
        "log_level": "info"
    }
    ```
5. Run dmsg-server 2 `./bin/dmsg-discovery config2.json`
    ```json
    {
        "public_key": "02af0fba11cbf48ca30f58f06ded42a6552b77d4986b417ab5c312763bf056fd84",
        "secret_key": "1fde169ac36bc1795315ca61be494e22b329650e99fcb4f2ac3b39d344837a53",
        "discovery": "http://localhost:9090",
        "local_address": "localhost:8084",
        "public_address": ":8084",
        "health_endpoint_address": "localhost:8083",
        "max_sessions": 10,
        "update_interval": 0,
        "log_level": "info"
    }
    ```
6. Check `http://localhost:9090/dmsg-discovery/available_servers` and see if the entries are in descending order of `max_sessions`