### PR TITLE
Remove timestamp validation for client entry

### DIFF
--- a/cmd/dmsg-discovery/internal/api/api.go
+++ b/cmd/dmsg-discovery/internal/api/api.go
@@ -181,6 +181,11 @@ func (a *API) setEntry() func(w http.ResponseWriter, r *http.Request) {
 		}
 
 		validateTimestamp := !a.enableLoadTesting
+		// we donot validate timestamp when entry is a client as the client no longer updates itself
+		// periodically and so the timestamp is never updated
+		if entry.Client != nil {
+			validateTimestamp = false
+		}
 		if err := entry.Validate(validateTimestamp); err != nil {
 			a.handleError(w, r, err)
 			return


### PR DESCRIPTION
Fixes #	

 Changes:	
- Removed timestamp validation for client entries

How to test this PR:
