### PR TITLE
Add func field retrier to log

### DIFF
--- a/netutil/retrier.go
+++ b/netutil/retrier.go
@@ -78,11 +78,11 @@ func (r *Retrier) Do(ctx context.Context, f RetryFunc) error {
 			if newBO := time.Duration(float64(bo) * r.factor); r.maxBO == 0 || newBO <= r.maxBO {
 				bo = newBO
 			}
-			if r.log != nil {
-				r.log.WithError(err).WithField("current_backoff", bo).Debug("Retrying...")
-			}
 			select {
 			case <-t.C:
+				if r.log != nil {
+					r.log.WithError(err).WithField("current_backoff", bo).Debug("Retrying...")
+				}
 				t.Reset(bo)
 				continue
 			case <-ctx.Done():

--- a/netutil/retrier.go
+++ b/netutil/retrier.go
@@ -36,13 +36,14 @@ type Retrier struct {
 
 // NewRetrier returns a retrier that is ready to call Do() method
 func NewRetrier(log logrus.FieldLogger, initBO, maxBO time.Duration, tries int64, factor float64) *Retrier {
+	logger := log.WithField("func", "retrier")
 	return &Retrier{
 		initBO: initBO,
 		maxBO:  maxBO,
 		tries:  tries,
 		factor: factor,
 		errWl:  make(map[error]struct{}),
-		log:    log,
+		log:    logger,
 	}
 }
 

--- a/netutil/retrier.go
+++ b/netutil/retrier.go
@@ -81,7 +81,7 @@ func (r *Retrier) Do(ctx context.Context, f RetryFunc) error {
 			select {
 			case <-t.C:
 				if r.log != nil {
-					r.log.WithError(err).WithField("current_backoff", bo).Debug("Retrying...")
+					r.log.WithError(err).WithField("current_backoff", bo).Warn("Retrying...")
 				}
 				t.Reset(bo)
 				continue


### PR DESCRIPTION
Fixes [#skywire-1040](https://github.com/skycoin/skywire/issues/1040)

 Changes:	
- Added func field retrier to log
- Moved log under the ticker
- Changed debug to Warn

How to test this PR:
Given here [#skywire-1111](https://github.com/skycoin/skywire/pull/1111)