### PR TITLE
set DMSGPTYTERM env variable on starting UI

### DIFF
--- a/pkg/dmsgpty/ui.go
+++ b/pkg/dmsgpty/ui.go
@@ -178,6 +178,9 @@ func (ui *UI) Handler() http.HandlerFunc {
 			}
 		}()
 
+		// set DMSGPTYTERM=1 env on starting dmsgpty-ui
+		ptyC.Write([]byte("export DMSGPTYTERM=1\n")) //nolint
+
 		// io
 		done, once := make(chan struct{}), new(sync.Once)
 		closeDone := func() { once.Do(func() { close(done) }) }


### PR DESCRIPTION
Fixes [skywire#1219 (a part of)](https://github.com/skycoin/skywire/issues/1219)

 Changes:	
- add `export DMSGPTYTERM=1` at the beginning of dmsgpty-ui.

How to test this PR:
check [here](https://github.com/skycoin/skywire/pull/1223)