### PR TITLE
setup-node routine for new dmsg-server

### DIFF
--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -141,7 +141,7 @@ func (ce *Client) Serve(ctx context.Context) {
 	cancellabelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	setupNodeTicker := time.NewTicker(5 * time.Minute)
+	setupNodeTicker := time.NewTicker(1 * time.Minute)
 
 	go func(ctx context.Context) {
 		select {
@@ -217,7 +217,7 @@ func (ce *Client) Serve(ctx context.Context) {
 				return
 			}
 		case <-setupNodeTicker.C:
-			return
+			continue
 		}
 	}
 }

--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -141,6 +141,8 @@ func (ce *Client) Serve(ctx context.Context) {
 	cancellabelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	setupNodeTicker := time.NewTicker(5 * time.Minute)
+
 	go func(ctx context.Context) {
 		select {
 		case <-ctx.Done():
@@ -214,6 +216,8 @@ func (ce *Client) Serve(ctx context.Context) {
 			if isClosed(ce.done) {
 				return
 			}
+		case <-setupNodeTicker.C:
+			return
 		}
 	}
 }


### PR DESCRIPTION
Fixes [skywire#1265](https://github.com/skycoin/skywire/issues/1265)

 Changes:	
- add a ticker named `setupNodeTicker` to check dmsg-discovery each minute for new dmsg-servers

How to test this PR:
- clone dmsg on this PR branch
- change pkg -> dmsg -> client.go -> line 144 from `1 * time.Minute` to `10 * time.Second*
- build binaries by `make build`
- start redis-server, then run dmsg-discovery by `./bin/dmsg-discovery -t` and first dmsg-server by `./bin/dmsg-server ./integration/configs/dmsgserver1.json`
- clone skywire on develop branch, uncomment `replace dmsg...` on `go.mod` and run `make dep` command
- run setup node by follow config as `./setup-node config.json`:
  ```
  {
  "public_key": "02603d53d49b6575a0b8cee05b70dd23c86e42cd6cba99af769d61a6196ea2bcb1",
  "secret_key": "8535d62ea3d19c8ce09e77ffe0f173c733e1798b23c84d9b72d2a70888c90a3b",
  "dmsg": {
    "discovery": "http://localhost:9090",
    "sessions_count": 0
  },
  "transport_discovery": "http://localhost:9091"
  }
  ```
- check logs for 10 second, new routine for check dmsg-servers run
- run second dmsg-server by `./bin/dmsg-server ./integration/configs/dmsgserver2.json`
- check setup-node logs again at last for 10 second, should new dmsg-server session established