### PR TITLE
Fix naming of Victoria metrics

### DIFF
--- a/internal/discmetrics/victoria_metrics.go
+++ b/internal/discmetrics/victoria_metrics.go
@@ -13,8 +13,8 @@ type VictoriaMetrics struct {
 // NewVictoriaMetrics returns the Victoria Metrics implementation of Metrics.
 func NewVictoriaMetrics() *VictoriaMetrics {
 	return &VictoriaMetrics{
-		clientsCount: metricsutil.NewVictoriaMetricsIntGauge("clients_count"),
-		serversCount: metricsutil.NewVictoriaMetricsIntGauge("servers_count"),
+		clientsCount: metricsutil.NewVictoriaMetricsIntGauge("dmsg_discovery_clients_count"),
+		serversCount: metricsutil.NewVictoriaMetricsIntGauge("dmsg_discovery_servers_count"),
 	}
 }
 

--- a/internal/servermetrics/victoria_metrics.go
+++ b/internal/servermetrics/victoria_metrics.go
@@ -24,15 +24,15 @@ type VictoriaMetrics struct {
 // NewVictoriaMetrics returns the Victoria Metrics implementation of Metrics.
 func NewVictoriaMetrics() *VictoriaMetrics {
 	return &VictoriaMetrics{
-		packetsPerMinute:   metricsutil.NewVictoriaMetricsUintGauge("packets_per_minute"),
-		packetsPerSecond:   metricsutil.NewVictoriaMetricsUintGauge("packets_per_second"),
-		clientsCount:       metricsutil.NewVictoriaMetricsIntGauge("clients_count"),
-		activeSessions:     metricsutil.NewVictoriaMetricsIntGauge("vm_active_sessions_count"),
-		successfulSessions: metrics.GetOrCreateCounter("vm_session_success_total"),
-		failedSessions:     metrics.GetOrCreateCounter("vm_session_fail_total"),
-		activeStreams:      metricsutil.NewVictoriaMetricsIntGauge("vm_active_streams_count"),
-		successfulStreams:  metrics.GetOrCreateCounter("vm_stream_success_total"),
-		failedStreams:      metrics.GetOrCreateCounter("vm_stream_fail_total"),
+		packetsPerMinute:   metricsutil.NewVictoriaMetricsUintGauge("dmsg_server_packets_per_minute"),
+		packetsPerSecond:   metricsutil.NewVictoriaMetricsUintGauge("dmsg_server_packets_per_second"),
+		clientsCount:       metricsutil.NewVictoriaMetricsIntGauge("dmsg_server_clients_count"),
+		activeSessions:     metricsutil.NewVictoriaMetricsIntGauge("dmsg_server_vm_active_sessions_count"),
+		successfulSessions: metrics.GetOrCreateCounter("dmsg_server_vm_session_success_total"),
+		failedSessions:     metrics.GetOrCreateCounter("dmsg_server_vm_session_fail_total"),
+		activeStreams:      metricsutil.NewVictoriaMetricsIntGauge("dmsg_server_vm_active_streams_count"),
+		successfulStreams:  metrics.GetOrCreateCounter("dmsg_server_vm_stream_success_total"),
+		failedStreams:      metrics.GetOrCreateCounter("dmsg_server_vm_stream_fail_total"),
 	}
 }
 


### PR DESCRIPTION
Added service prefix to dmsg-discovery and server metrics exposed to
prevent clashes.

Fixes https://github.com/SkycoinPro/skywire-services/issues/573

 Changes:	
- prepend service name to metrics

How to test this PR:

1. Checkout branch
2. Run redis-server
3. Make build
4. `./bin/dmsg-discovery -t -m :2121`
5. `./bin/dmsg-server ./integration/configs/dmsgserver1.json -m :2122`
6. Navigate to localhost:2121/metrics and check the metrics names 
