### PR TITLE
Feat/release pipeline

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,18 @@ environment:
       appveyor_build_worker_image: Previous Visual Studio 2019
     - job_name: Deploy
       appveyor_build_worker_image: Ubuntu2004
+  
+    # For release, by pushing tag
+    - job_name: make-release-linux
+      appveyor_build_worker_image: ubuntu2004
+      GOARCH: amd64
+    - job_name: make-release-darwin
+      appveyor_build_worker_image: macos-bigsur
+      GOARCH: amd64
+    - job_name: make-release-windows
+      appveyor_build_worker_image: Previous Visual Studio 2019
+      GOARCH: amd64
+    
 
 for:
   - # Linux and MacOS
@@ -52,6 +64,45 @@ for:
 
     build_script:
       - make build-windows
+
+  - # Release (Linux)
+    skip_non_tags: true
+    matrix:
+      only:
+        - job_name: make-release-linux
+    install:
+      - sudo apt update
+      - sudo snap install goreleaser --classic
+      - make dep-github-release
+    build_script:
+      - make github-release
+
+  - # Release (Darwin)
+    skip_non_tags: true
+    matrix:
+      only:
+        - job_name: make-release-darwin
+    install:
+      - brew install goreleaser
+      - brew install gh
+      - brew install jq
+      - brew install wget
+    build_script:
+      - make github-release-darwin
+
+  - # Release (Windows)
+    skip_non_tags: true
+    matrix:
+      only:
+        - job_name: make-release-windows
+    install:
+      - ps: Invoke-WebRequest "https://github.com/goreleaser/goreleaser/releases/download/v1.8.3/goreleaser_Windows_x86_64.zip" -o goreleaser.zip
+      - ps: Expand-Archive goreleaser.zip
+      - ps: Invoke-WebRequest "https://github.com/cli/cli/releases/download/v2.13.0/gh_2.13.0_windows_amd64.zip" -o gh.zip
+      - ps: Expand-Archive gh.zip
+      - ps: choco install make
+    build_script:
+      - make github-release-windows
 
   - # Deploy
     build: off

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ bin/
 
 /hello.txt
 /integration/integration-pids.csv
+
+/dist

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -7,7 +7,7 @@ release:
   # Note: it can only be one: either github or gitlab or gitea
   github:
     owner: skycoin
-    name: skywire
+    name: dmsg
 
   prerelease: true
 

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -1,0 +1,113 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  # Note: it can only be one: either github or gitlab or gitea
+  github:
+    owner: skycoin
+    name: skywire
+
+  prerelease: true
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: dmsg-discovery
+    binary: dmsg-discovery
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=1
+    main: ./cmd/dmsg-discovery/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsg-server
+    binary: dmsg-server
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsg-server/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgget
+    binary: dmsgget
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgget/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgpty-ui
+    binary: dmsgpty-ui
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgpty-ui/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgpty-host
+    binary: dmsgpty-host
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgpty-host/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgpty-cli
+    binary: dmsgpty-cli
+    goos:
+      - darwin
+    goarch:
+      - arm64
+      - amd64
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgpty-cli/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+archives:
+  - id: archive
+    format: tar.gz
+    wrap_in_directory: false
+    name_template: 'dmsg-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    builds:
+      - dmsg-discovery
+      - dmsg-server
+      - dmsgpty-ui
+      - dmsgpty-host
+      - dmsgget
+      - dmsgpty-cli
+    allow_different_binary_count: true
+
+checksum:
+  name_template: 'checksums.txt'  
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser-darwin.yml
+++ b/.goreleaser-darwin.yml
@@ -14,6 +14,7 @@ release:
 before:
   hooks:
     - go mod tidy
+
 builds:
   - id: dmsg-discovery
     binary: dmsg-discovery

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -17,8 +17,8 @@ before:
     - sed -i '/go conn.handleCall(msg)/c\conn.handleCall(msg)' ./vendor/github.com/godbus/dbus/v5/conn.go
 builds:
 
-  - id: skywire-visor-amd64
-    binary: skywire-visor
+  - id: dmsg-discovery-amd64
+    binary: dmsg-discovery
     goos:
       - linux
     goarch:
@@ -26,11 +26,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/skywire-visor/
+    main: ./cmd/dmsg-discovery/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-visor-arm64
-    binary: skywire-visor
+  - id: dmsg-discovery-arm64
+    binary: dmsg-discovery
     goos:
       - linux
     goarch:
@@ -38,11 +38,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/skywire-visor/
+    main: ./cmd/dmsg-discovery/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-visor-arm
-    binary: skywire-visor
+  - id: dmsg-discovery-arm
+    binary: dmsg-discovery
     goos:
       - linux
     goarch:
@@ -52,11 +52,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/skywire-visor/
+    main: ./cmd/dmsg-discovery/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-visor-armhf
-    binary: skywire-visor
+  - id: dmsg-discovery-armhf
+    binary: dmsg-discovery
     goos:
       - linux
     goarch:
@@ -66,11 +66,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/skywire-visor/
+    main: ./cmd/dmsg-discovery/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-cli-amd64
-    binary: skywire-cli
+  - id: dmsg-server-amd64
+    binary: dmsg-server
     goos:
       - linux
     goarch:
@@ -78,11 +78,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/skywire-cli/
+    main: ./cmd/dmsg-server/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-cli-arm64
-    binary: skywire-cli
+  - id: dmsg-server-arm64
+    binary: dmsg-server
     goos:
       - linux
     goarch:
@@ -90,11 +90,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/skywire-cli/
+    main: ./cmd/dmsg-server/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-cli-arm
-    binary: skywire-cli
+  - id: dmsg-server-arm
+    binary: dmsg-server
     goos:
       - linux
     goarch:
@@ -104,11 +104,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/skywire-cli/
+    main: ./cmd/dmsg-server/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skywire-cli-armhf
-    binary: skywire-cli
+  - id: dmsg-server-armhf
+    binary: dmsg-server
     goos:
       - linux
     goarch:
@@ -118,11 +118,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/skywire-cli/
+    main: ./cmd/dmsg-server/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skychat-amd64
-    binary: apps/skychat
+  - id: dmsgget-amd64
+    binary: dmsgget
     goos:
       - linux
     goarch:
@@ -130,11 +130,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/apps/skychat/
+    main: ./cmd/dmsgget/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
-  - id: skychat-arm64
-    binary: apps/skychat
+  - id: dmsgget-arm64
+    binary: dmsgget
     goos:
       - linux
     goarch:
@@ -142,11 +142,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/apps/skychat/
+    main: ./cmd/dmsgget/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skychat-arm
-    binary: apps/skychat
+  - id: dmsgget-arm
+    binary: dmsgget
     goos:
       - linux
     goarch:
@@ -156,11 +156,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/apps/skychat/
+    main: ./cmd/dmsgget/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skychat-armhf
-    binary: apps/skychat
+  - id: dmsgget-armhf
+    binary: dmsgget
     goos:
       - linux
     goarch:
@@ -170,11 +170,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/apps/skychat/
+    main: ./cmd/dmsgget/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skysocks-amd64
-    binary: apps/skysocks
+  - id: dmsgpty-ui-amd64
+    binary: dmsgpty-ui
     goos:
       - linux
     goarch:
@@ -182,11 +182,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/apps/skysocks/
+    main: ./cmd/dmsgpty-ui/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
-  - id: skysocks-arm64
-    binary: apps/skysocks
+  - id: dmsgpty-ui-arm64
+    binary: dmsgpty-ui
     goos:
       - linux
     goarch:
@@ -194,11 +194,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/apps/skysocks/
+    main: ./cmd/dmsgpty-ui/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skysocks-arm
-    binary: apps/skysocks
+  - id: dmsgpty-ui-arm
+    binary: dmsgpty-ui
     goos:
       - linux
     goarch:
@@ -208,11 +208,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/apps/skysocks/
+    main: ./cmd/dmsgpty-ui/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skysocks-armhf
-    binary: apps/skysocks
+  - id: dmsgpty-ui-armhf
+    binary: dmsgpty-ui
     goos:
       - linux
     goarch:
@@ -222,11 +222,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/apps/skysocks/
+    main: ./cmd/dmsgpty-ui/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skysocks-client-amd64
-    binary: apps/skysocks-client
+  - id: dmsgpty-cli-amd64
+    binary: dmsgpty-cli
     goos:
       - linux
     goarch:
@@ -234,11 +234,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/apps/skysocks-client/
+    main: ./cmd/dmsgpty-cli/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
-  - id: skysocks-client-arm64
-    binary: apps/skysocks-client
+  - id: dmsgpty-cli-arm64
+    binary: dmsgpty-cli
     goos:
       - linux
     goarch:
@@ -246,11 +246,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/apps/skysocks-client/
+    main: ./cmd/dmsgpty-cli/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skysocks-client-arm
-    binary: apps/skysocks-client
+  - id: dmsgpty-cli-arm
+    binary: dmsgpty-cli
     goos:
       - linux
     goarch:
@@ -260,11 +260,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/apps/skysocks-client/
+    main: ./cmd/dmsgpty-cli/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: skysocks-client-armhf
-    binary: apps/skysocks-client
+  - id: dmsgpty-cli-armhf
+    binary: dmsgpty-cli
     goos:
       - linux
     goarch:
@@ -274,11 +274,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/apps/skysocks-client/
+    main: ./cmd/dmsgpty-cli/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: vpn-server-amd64
-    binary: apps/vpn-server
+  - id: dmsgpty-host-amd64
+    binary: dmsgpty-host
     goos:
       - linux
     goarch:
@@ -286,11 +286,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/apps/vpn-server/
+    main: ./cmd/dmsgpty-host/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
-  - id: vpn-server-arm64
-    binary: apps/vpn-server
+  - id: dmsgpty-host-arm64
+    binary: dmsgpty-host
     goos:
       - linux
     goarch:
@@ -298,11 +298,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/apps/vpn-server/
+    main: ./cmd/dmsgpty-host/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: vpn-server-arm
-    binary: apps/vpn-server
+  - id: dmsgpty-host-arm
+    binary: dmsgpty-host
     goos:
       - linux
     goarch:
@@ -312,11 +312,11 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/apps/vpn-server/
+    main: ./cmd/dmsgpty-host/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
-  - id: vpn-server-armhf
-    binary: apps/vpn-server
+  - id: dmsgpty-host-armhf
+    binary: dmsgpty-host
     goos:
       - linux
     goarch:
@@ -326,121 +326,57 @@ builds:
     env:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/apps/vpn-server/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
-
-  - id: vpn-client-amd64
-    binary: apps/vpn-client
-    goos:
-      - linux
-    goarch:
-      - amd64
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
-    main: ./cmd/apps/vpn-client/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
-
-  - id: vpn-client-arm64
-    binary: apps/vpn-client
-    goos:
-      - linux
-    goarch:
-      - arm64
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
-    main: ./cmd/apps/vpn-client/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
-
-  - id: vpn-client-arm
-    binary: apps/vpn-client
-    goos:
-      - linux
-    goarch:
-      - arm
-    goarm:
-      - 6
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
-    main: ./cmd/apps/vpn-client/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
-
-  - id: vpn-client-armhf
-    binary: apps/vpn-client
-    goos:
-      - linux
-    goarch:
-      - arm
-    goarm:
-      - 7
-    env:
-      - CGO_ENABLED=1
-      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
-    main: ./cmd/apps/vpn-client/
+    main: ./cmd/dmsgpty-host/
     ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
 
 archives:
   - id: amd64
     format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
-    files:
-      - dmsghttp-config.json
+    name_template: 'dmsg-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
-      - skywire-visor-amd64
-      - skywire-cli-amd64
-      - skysocks-amd64
-      - skysocks-client-amd64
-      - skychat-amd64
-      - vpn-server-amd64
-      - vpn-client-amd64
+      - dmsg-discovery-amd64
+      - dmsg-server-amd64
+      - dmsgpty-ui-amd64
+      - dmsgpty-cli-amd64
+      - dmsgget-amd64
+      - dmsgpty-host-amd64
 
   - id: arm64
     format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
-    files:
-      - dmsghttp-config.json
+    name_template: 'dmsg-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
-      - skywire-visor-arm64
-      - skywire-cli-arm64
-      - skysocks-arm64
-      - skysocks-client-arm64
-      - skychat-arm64
-      - vpn-server-arm64
-      - vpn-client-arm64
+      - dmsg-discovery-arm64
+      - dmsg-server-arm64
+      - dmsgpty-ui-arm64
+      - dmsgpty-cli-arm64
+      - dmsgget-arm64
+      - dmsgpty-host-arm64
 
   - id: arm
     format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
-    files:
-      - dmsghttp-config.json
+    name_template: 'dmsg-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
-      - skywire-visor-arm
-      - skywire-cli-arm
-      - skysocks-arm
-      - skysocks-client-arm
-      - skychat-arm
-      - vpn-server-arm
-      - vpn-client-arm
+      - dmsg-discovery-arm
+      - dmsg-server-arm
+      - dmsgpty-ui-arm
+      - dmsgpty-cli-arm
+      - dmsgget-arm
+      - dmsgpty-host-arm
 
   - id: armhf
     format: tar.gz
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}hf'
-    files:
-      - dmsghttp-config.json
+    name_template: 'dmsg-v{{ .Version }}-{{ .Os }}-{{ .Arch }}hf'
     builds:
-      - skywire-visor-armhf
-      - skywire-cli-armhf
-      - skysocks-armhf
-      - skysocks-client-armhf
-      - skychat-armhf
-      - vpn-server-armhf
-      - vpn-client-armhf
+      - dmsg-discovery-armhf
+      - dmsg-server-armhf
+      - dmsgpty-ui-armhf
+      - dmsgpty-cli-armhf
+      - dmsgget-armhf
+      - dmsgpty-host-armhf
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -1,0 +1,454 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  # Note: it can only be one: either github or gitlab or gitea
+  github:
+    owner: skycoin
+    name: skywire
+
+  #prerelease: true
+
+before:
+  hooks:
+    - go mod tidy
+    - sed -i '/go conn.handleCall(msg)/c\conn.handleCall(msg)' ./vendor/github.com/godbus/dbus/v5/conn.go
+builds:
+
+  - id: skywire-visor-amd64
+    binary: skywire-visor
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/skywire-visor/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-visor-arm64
+    binary: skywire-visor
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/skywire-visor/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-visor-arm
+    binary: skywire-visor
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/skywire-visor/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-visor-armhf
+    binary: skywire-visor
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/skywire-visor/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-cli-amd64
+    binary: skywire-cli
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/skywire-cli/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-cli-arm64
+    binary: skywire-cli
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/skywire-cli/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-cli-arm
+    binary: skywire-cli
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/skywire-cli/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skywire-cli-armhf
+    binary: skywire-cli
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/skywire-cli/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skychat-amd64
+    binary: apps/skychat
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/apps/skychat/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: skychat-arm64
+    binary: apps/skychat
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/apps/skychat/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skychat-arm
+    binary: apps/skychat
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/apps/skychat/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skychat-armhf
+    binary: apps/skychat
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/apps/skychat/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skysocks-amd64
+    binary: apps/skysocks
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/apps/skysocks/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: skysocks-arm64
+    binary: apps/skysocks
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/apps/skysocks/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skysocks-arm
+    binary: apps/skysocks
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/apps/skysocks/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skysocks-armhf
+    binary: apps/skysocks
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/apps/skysocks/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skysocks-client-amd64
+    binary: apps/skysocks-client
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/apps/skysocks-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: skysocks-client-arm64
+    binary: apps/skysocks-client
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/apps/skysocks-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skysocks-client-arm
+    binary: apps/skysocks-client
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/apps/skysocks-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: skysocks-client-armhf
+    binary: apps/skysocks-client
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/apps/skysocks-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: vpn-server-amd64
+    binary: apps/vpn-server
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/apps/vpn-server/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: vpn-server-arm64
+    binary: apps/vpn-server
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/apps/vpn-server/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: vpn-server-arm
+    binary: apps/vpn-server
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/apps/vpn-server/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: vpn-server-armhf
+    binary: apps/vpn-server
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/apps/vpn-server/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: vpn-client-amd64
+    binary: apps/vpn-client
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
+    main: ./cmd/apps/vpn-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: vpn-client-arm64
+    binary: apps/vpn-client
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
+    main: ./cmd/apps/vpn-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: vpn-client-arm
+    binary: apps/vpn-client
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 6
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
+    main: ./cmd/apps/vpn-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+  - id: vpn-client-armhf
+    binary: apps/vpn-client
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - 7
+    env:
+      - CGO_ENABLED=1
+      - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
+    main: ./cmd/apps/vpn-client/
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+
+archives:
+  - id: amd64
+    format: tar.gz
+    wrap_in_directory: false
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    files:
+      - dmsghttp-config.json
+    builds:
+      - skywire-visor-amd64
+      - skywire-cli-amd64
+      - skysocks-amd64
+      - skysocks-client-amd64
+      - skychat-amd64
+      - vpn-server-amd64
+      - vpn-client-amd64
+
+  - id: arm64
+    format: tar.gz
+    wrap_in_directory: false
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    files:
+      - dmsghttp-config.json
+    builds:
+      - skywire-visor-arm64
+      - skywire-cli-arm64
+      - skysocks-arm64
+      - skysocks-client-arm64
+      - skychat-arm64
+      - vpn-server-arm64
+      - vpn-client-arm64
+
+  - id: arm
+    format: tar.gz
+    wrap_in_directory: false
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    files:
+      - dmsghttp-config.json
+    builds:
+      - skywire-visor-arm
+      - skywire-cli-arm
+      - skysocks-arm
+      - skysocks-client-arm
+      - skychat-arm
+      - vpn-server-arm
+      - vpn-client-arm
+
+  - id: armhf
+    format: tar.gz
+    wrap_in_directory: false
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}hf'
+    files:
+      - dmsghttp-config.json
+    builds:
+      - skywire-visor-armhf
+      - skywire-cli-armhf
+      - skysocks-armhf
+      - skysocks-client-armhf
+      - skychat-armhf
+      - vpn-server-armhf
+      - vpn-client-armhf
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -7,7 +7,7 @@ release:
   # Note: it can only be one: either github or gitlab or gitea
   github:
     owner: skycoin
-    name: skywire
+    name: dmsg
 
   #prerelease: true
 

--- a/.goreleaser-linux.yml
+++ b/.goreleaser-linux.yml
@@ -14,7 +14,7 @@ release:
 before:
   hooks:
     - go mod tidy
-    - sed -i '/go conn.handleCall(msg)/c\conn.handleCall(msg)' ./vendor/github.com/godbus/dbus/v5/conn.go
+
 builds:
 
   - id: dmsg-discovery-amd64
@@ -27,7 +27,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
     main: ./cmd/dmsg-discovery/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-discovery-arm64
     binary: dmsg-discovery
@@ -39,7 +39,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     main: ./cmd/dmsg-discovery/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-discovery-arm
     binary: dmsg-discovery
@@ -53,7 +53,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
     main: ./cmd/dmsg-discovery/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-discovery-armhf
     binary: dmsg-discovery
@@ -67,7 +67,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
     main: ./cmd/dmsg-discovery/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-server-amd64
     binary: dmsg-server
@@ -79,7 +79,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc
     main: ./cmd/dmsg-server/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-server-arm64
     binary: dmsg-server
@@ -91,7 +91,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     main: ./cmd/dmsg-server/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-server-arm
     binary: dmsg-server
@@ -105,7 +105,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
     main: ./cmd/dmsg-server/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsg-server-armhf
     binary: dmsg-server
@@ -119,7 +119,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
     main: ./cmd/dmsg-server/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgget-amd64
     binary: dmsgget
@@ -143,7 +143,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     main: ./cmd/dmsgget/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgget-arm
     binary: dmsgget
@@ -157,7 +157,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
     main: ./cmd/dmsgget/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgget-armhf
     binary: dmsgget
@@ -171,7 +171,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
     main: ./cmd/dmsgget/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-ui-amd64
     binary: dmsgpty-ui
@@ -195,7 +195,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     main: ./cmd/dmsgpty-ui/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-ui-arm
     binary: dmsgpty-ui
@@ -209,7 +209,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
     main: ./cmd/dmsgpty-ui/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-ui-armhf
     binary: dmsgpty-ui
@@ -223,7 +223,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
     main: ./cmd/dmsgpty-ui/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-cli-amd64
     binary: dmsgpty-cli
@@ -247,7 +247,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     main: ./cmd/dmsgpty-cli/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-cli-arm
     binary: dmsgpty-cli
@@ -261,7 +261,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
     main: ./cmd/dmsgpty-cli/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-cli-armhf
     binary: dmsgpty-cli
@@ -275,7 +275,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
     main: ./cmd/dmsgpty-cli/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-host-amd64
     binary: dmsgpty-host
@@ -299,7 +299,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc
     main: ./cmd/dmsgpty-host/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-host-arm
     binary: dmsgpty-host
@@ -313,7 +313,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabi-cross/bin/arm-linux-musleabi-gcc
     main: ./cmd/dmsgpty-host/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
   - id: dmsgpty-host-armhf
     binary: dmsgpty-host
@@ -327,7 +327,7 @@ builds:
       - CGO_ENABLED=1
       - CC=/home/appveyor/projects/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc
     main: ./cmd/dmsgpty-host/
-    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}_{{.Arch}}
+    ldflags: -s -w -linkmode external -extldflags '-static' -buildid= -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
   - id: amd64

--- a/.goreleaser-windows.yml
+++ b/.goreleaser-windows.yml
@@ -7,7 +7,7 @@ release:
   # Note: it can only be one: either github or gitlab or gitea
   github:
     owner: skycoin
-    name: skywire
+    name: dmsg
 
   prerelease: true
 

--- a/.goreleaser-windows.yml
+++ b/.goreleaser-windows.yml
@@ -1,0 +1,76 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+
+release:
+  # Repo in which the release will be created.
+  # Default is extracted from the origin remote URL or empty if its private hosted.
+  # Note: it can only be one: either github or gitlab or gitea
+  github:
+    owner: skycoin
+    name: skywire
+
+  prerelease: true
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: skywire-visor
+    binary: skywire-visor
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=1
+    main: ./cmd/skywire-visor/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}
+
+  - id: skywire-cli
+    binary: skywire-cli
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/skywire-cli/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: vpn-client
+    binary: apps/vpn-client
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/apps/vpn-client/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+archives:
+  - id: archive
+    format: zip
+    wrap_in_directory: false
+    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    files:
+      - dmsghttp-config.json
+    builds:
+      - skywire-visor
+      - skywire-cli
+      - vpn-client
+    allow_different_binary_count: true
+
+checksum:
+  name_template: 'checksums.txt'  
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser-windows.yml
+++ b/.goreleaser-windows.yml
@@ -15,8 +15,8 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - id: skywire-visor
-    binary: skywire-visor
+  - id: dmsg-discovery
+    binary: dmsg-discovery
     goos:
       - windows
     goarch:
@@ -24,23 +24,11 @@ builds:
       - 386
     env:
       - CGO_ENABLED=1
-    main: ./cmd/skywire-visor/
-    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}} -X github.com/skycoin/skywire/pkg/visor.BuildTag={{.Os}}
-
-  - id: skywire-cli
-    binary: skywire-cli
-    goos:
-      - windows
-    goarch:
-      - amd64
-      - 386
-    env:
-      - CGO_ENABLED=0
-    main: ./cmd/skywire-cli/
+    main: ./cmd/dmsg-discovery/
     ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
-  - id: vpn-client
-    binary: apps/vpn-client
+  - id: dmsg-server
+    binary: dmsg-server
     goos:
       - windows
     goarch:
@@ -48,20 +36,69 @@ builds:
       - 386
     env:
       - CGO_ENABLED=0
-    main: ./cmd/apps/vpn-client/
+    main: ./cmd/dmsg-server/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgget
+    binary: dmsgget
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgget/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+  
+  - id: dmsgpty-ui
+    binary: dmsgpty-ui
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgpty-ui/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgpty-cli
+    binary: dmsgpty-cli
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgpty-cli/
+    ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
+
+  - id: dmsgpty-host
+    binary: dmsgpty-host
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./cmd/dmsgpty-host/
     ldflags: -s -w -X github.com/skycoin/skywire-utilities/pkg/buildinfo.version=v{{.Version}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.commit={{.ShortCommit}} -X github.com/skycoin/skywire-utilities/pkg/buildinfo.date={{.Date}}
 
 archives:
   - id: archive
     format: zip
     wrap_in_directory: false
-    name_template: 'skywire-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
-    files:
-      - dmsghttp-config.json
+    name_template: 'dmsg-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
     builds:
-      - skywire-visor
-      - skywire-cli
-      - vpn-client
+      - dmsg-discovery
+      - dmsg-server
+      - dmsgget
+      - dmsgpty-cli
+      - dmsgpty-ui
+      - dmsgpty-host
     allow_different_binary_count: true
 
 checksum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2022-07-13
-### Added
 
+## 1.3.0
+
+### Added
 - add `start` command to `dmsg-server`, should used like `./dmsg-server start config.json`
 - add `gen` command to generate config, with two flag `-o` for output file and `-t` for using test env values
+
+### Changed
+- TBD

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,18 @@ build-deploy: ## Build for deployment Docker images
 build-docker:
 	./docker/scripts/docker-push.sh -t "develop" -b
 
+snapshot-linux: snapshot-clean
+	goreleaser --snapshot --config .goreleaser-linux.yml --skip-publish --rm-dist
+
+snapshot-darwin: snapshot-clean
+	goreleaser --snapshot --config .goreleaser-darwin.yml --skip-publish --rm-dist
+
+snapshot-windows: snapshot-clean
+	goreleaser --snapshot --config .goreleaser-windows.yml --skip-publish --rm-dist
+
+snapshot-clean: ## Cleans snapshot / release
+	rm -rf ./dist
+
 start-db: ## Init local database env.
 	source ./integration/env.sh && init_redis
 

--- a/pkg/dmsgtest/env_test.go
+++ b/pkg/dmsgtest/env_test.go
@@ -28,7 +28,7 @@ func TestEnv(t *testing.T) {
 		}
 		for i, c := range cases {
 			env := NewEnv(t, timeout)
-			err := env.Startup(0, c.ServerN, c.ClientN, &dmsg.Config{
+			err := env.Startup(5*time.Second, c.ServerN, c.ClientN, &dmsg.Config{
 				MinSessions: c.MinSessions,
 			})
 			require.NoError(t, err, i)

--- a/pkg/noise/read_writer_test.go
+++ b/pkg/noise/read_writer_test.go
@@ -50,8 +50,8 @@ func TestNewReadWriter(t *testing.T) {
 
 		hsCh := make(chan error, 2)
 		defer close(hsCh)
-		go func() { hsCh <- aRW.Handshake(time.Second) }()
-		go func() { hsCh <- bRW.Handshake(time.Second) }()
+		go func() { hsCh <- aRW.Handshake(5 * time.Second) }()
+		go func() { hsCh <- bRW.Handshake(5 * time.Second) }()
 		require.NoError(t, <-hsCh)
 		require.NoError(t, <-hsCh)
 
@@ -186,8 +186,8 @@ func TestReadWriterXKPattern(t *testing.T) {
 	rwR := NewReadWriter(connR, nR)
 
 	errCh := make(chan error)
-	go func() { errCh <- rwR.Handshake(time.Second) }()
-	require.NoError(t, rwI.Handshake(time.Second))
+	go func() { errCh <- rwR.Handshake(5 * time.Second) }()
+	require.NoError(t, rwI.Handshake(5*time.Second))
 	require.NoError(t, <-errCh)
 
 	go func() {


### PR DESCRIPTION
Fixes #196 

 Changes:	
- add `goreleaser` config and `appveyor` job for release dmsg binaries
- add v1.2.0 for last changes used in product

How to test this PR:
- On local, could test it by `snapshot-OS` like `linux`, `darwin` or `windows`