### PR TITLE
remove useless flags

### DIFF
--- a/cmd/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg-server/commands/start/root.go
@@ -30,7 +30,7 @@ var (
 )
 
 func init() {
-	sf.Init(RootCmd, "dmsg_srv", dmsgserver.DefaultConfigPath)
+	sf.Init(RootCmd, "dmsg_srv", "")
 }
 
 // RootCmd contains commands for dmsg-server


### PR DESCRIPTION
Fixes #216

 Changes:	
- remove useless flags `c` and `stdin` from help

How to test this PR:
- build binaries `make build`
- check help on start dmsg-server by `./dmsg-server start --help`