### PR TITLE
Bump Go images for Docker to 1.20-alpine

### DIFF
--- a/docker/images/dmsg-discovery/Dockerfile
+++ b/docker/images/dmsg-discovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS builder
+FROM golang:1.20-alpine AS builder
 ARG CGO_ENABLED=0
 
 ENV CGO_ENABLED=${CGO_ENABLED} \

--- a/docker/images/dmsg-server/Dockerfile
+++ b/docker/images/dmsg-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine AS builder
+FROM golang:1.20-alpine AS builder
 ARG CGO_ENABLED=0
 
 ENV CGO_ENABLED=${CGO_ENABLED} \


### PR DESCRIPTION
There has been a recent issue https://github.com/golang/go/issues/55078 that affects our ability to push dmsg docker images.

Bumping the image version for our base images from 1.16-alpine to 1.20 fixes that issue.

Fixes build issue here: https://github.com/skycoin/dmsg/actions/runs/5509536878/jobs/10042393359#step:4:128
