### PR TITLE
add ConnectedServersPK method

### DIFF
--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -472,6 +472,16 @@ func (ce *Client) AllEntries(ctx context.Context) (entries []string, err error) 
 	return entries, err
 }
 
+// ConnectedServersPK return all dmsg-servers keys
+func (ce *Client) ConnectedServersPK() []string {
+	sessions := ce.allClientSessions(ce.porter)
+	addrs := make([]string, len(sessions))
+	for i, s := range sessions {
+		addrs[i] = s.RemotePK().String()
+	}
+	return addrs
+}
+
 // ConnectionsSummary associates connected clients, and the servers that connect such clients.
 // Key: Client PK, Value: Slice of Server PKs
 type ConnectionsSummary map[cipher.PubKey][]cipher.PubKey

--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -472,7 +472,7 @@ func (ce *Client) AllEntries(ctx context.Context) (entries []string, err error) 
 	return entries, err
 }
 
-// ConnectedServersPK return all dmsg-servers keys
+// ConnectedServersPK return all connected dmsg-servers keys
 func (ce *Client) ConnectedServersPK() []string {
 	sessions := ce.allClientSessions(ce.porter)
 	addrs := make([]string, len(sessions))

--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -472,7 +472,7 @@ func (ce *Client) AllEntries(ctx context.Context) (entries []string, err error) 
 	return entries, err
 }
 
-// ConnectedServersPK return all connected dmsg-servers keys
+// ConnectedServersPK return keys of all connected dmsg servers
 func (ce *Client) ConnectedServersPK() []string {
 	sessions := ce.allClientSessions(ce.porter)
 	addrs := make([]string, len(sessions))


### PR DESCRIPTION
Fixes: # (Part of https://github.com/skycoin/skywire-services/issues/19)

 Changes:	
- add `ConnectedServersPK` method to `dmsg.Clients` for fetching current dmsg-servers connected list

How to test this PR:
_