### PR TITLE
fix all cli

### DIFF
--- a/cmd/dmsg-discovery/commands/dmsg-discovery.go
+++ b/cmd/dmsg-discovery/commands/dmsg-discovery.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	proxyproto "github.com/pires/go-proxyproto"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
@@ -64,21 +63,18 @@ func init() {
 	RootCmd.Flags().BoolVar(&testEnvironment, "test-environment", false, "distinguished between prod and test environment")
 	RootCmd.Flags().Var(&sk, "sk", "dmsg secret key\n")
 	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgPort", dmsg.DefaultDmsgHTTPPort, "dmsg port value\r")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsg-discovery")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
+
 }
 
 // RootCmd contains commands for dmsg-discovery
 var RootCmd = &cobra.Command{
 	Use:   "disc",
-	Short: "Dmsg Discovery Server for skywire",
+	Short: "DMSG Discovery Server",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐  ┌┬┐┬┌─┐┌─┐┌─┐┬  ┬┌─┐┬─┐┬ ┬
 	 │││││└─┐│ ┬───│││└─┐│  │ │└┐┌┘├┤ ├┬┘└┬┘
-	─┴┘┴ ┴└─┘└─┘  ─┴┘┴└─┘└─┘└─┘ └┘ └─┘┴└─ ┴ `,
+	─┴┘┴ ┴└─┘└─┘  ─┴┘┴└─┘└─┘└─┘ └┘ └─┘┴└─ ┴
+  ` + "DMSG Discovery Server",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -186,33 +182,10 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"
 
 func prepareDB(ctx context.Context, log *logging.Logger) store.Storer {
 	dbConf := &store.Config{

--- a/cmd/dmsg-discovery/dmsg-discovery.go
+++ b/cmd/dmsg-discovery/dmsg-discovery.go
@@ -1,8 +1,43 @@
 // package main cmd/dmsg-discovery/dmsg-discovery.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsg-discovery/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
 
+	"github.com/skycoin/dmsg/cmd/dmsg-discovery/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-cli")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -4,7 +4,6 @@ package commands
 import (
 	"log"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/spf13/cobra"
 
@@ -27,11 +26,12 @@ func init() {
 // RootCmd contains the root dmsg-server command
 var RootCmd = &cobra.Command{
 	Use:   "server",
-	Short: "Command Line Interface for DMSG-Server",
+	Short: "DMSG Server",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐   ┌─┐┌─┐┬─┐┬  ┬┌─┐┬─┐
 	││││││└─┐│ ┬ ─ └─┐├┤ ├┬┘└┐┌┘├┤ ├┬┘
-	─┴┘┴ ┴└─┘└─┘   └─┘└─┘┴└─ └┘ └─┘┴└─`,
+	─┴┘┴ ┴└─┘└─┘   └─┘└─┘┴└─ └┘ └─┘┴└─
+  ` + "DMSG Server",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -41,19 +41,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
+
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}

--- a/cmd/dmsg-server/commands/root.go
+++ b/cmd/dmsg-server/commands/root.go
@@ -16,11 +16,7 @@ func init() {
 		config.RootCmd,
 		start.RootCmd,
 	)
-	RootCmd.SetUsageTemplate(help)
-	var helpflag bool
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsg-server")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
+
 }
 
 // RootCmd contains the root dmsg-server command
@@ -41,18 +37,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes root CLI command.
 func Execute() {
-
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsg-server/dmsg-server.go
+++ b/cmd/dmsg-server/dmsg-server.go
@@ -1,8 +1,44 @@
 // package main cmd/dmsg-server/dmsg-server.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsg-server/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsg-server/commands"
+)
+
+func init() {
+	commands.RootCmd.SetUsageTemplate(help)
+	var helpflag bool
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsg-server")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsg/dmsg.go
+++ b/cmd/dmsg/dmsg.go
@@ -14,6 +14,7 @@ import (
 	dmsgptycli "github.com/skycoin/dmsg/cmd/dmsgpty-cli/commands"
 	dmsgptyhost "github.com/skycoin/dmsg/cmd/dmsgpty-host/commands"
 	dmsgptyui "github.com/skycoin/dmsg/cmd/dmsgpty-ui/commands"
+	dmsgweb "github.com/skycoin/dmsg/cmd/dmsgweb/commands"
 )
 
 func init() {
@@ -22,12 +23,14 @@ func init() {
 		dmsgptyhost.RootCmd,
 		dmsgptyui.RootCmd,
 	)
+	dmsgcurl.RootCmd.Use = "curl [OPTIONS] ... [URL]"
 	RootCmd.AddCommand(
 		dmsgptyCmd,
 		dmsgdisc.RootCmd,
 		dmsgserver.RootCmd,
 		dmsghttp.RootCmd,
 		dmsgcurl.RootCmd,
+		dmsgweb.RootCmd,
 	)
 	var helpflag bool
 	RootCmd.SetUsageTemplate(help)
@@ -41,11 +44,12 @@ func init() {
 // RootCmd contains all binaries which may be separately compiled as subcommands
 var RootCmd = &cobra.Command{
 	Use:   "dmsg",
-	Short: "Dmsg services & utilities",
+	Short: "DMSG services & utilities",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐
 	 │││││└─┐│ ┬
-	─┴┘┴ ┴└─┘└─┘ `,
+	─┴┘┴ ┴└─┘└─┘
+  ` + "DMSG services & utilities",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -54,11 +58,12 @@ var RootCmd = &cobra.Command{
 
 var dmsgptyCmd = &cobra.Command{
 	Use:   "pty",
-	Short: "Dmsg pseudoterminal (pty)",
+	Short: "DMSG pseudoterminal (pty)",
 	Long: `
 	┌─┐┌┬┐┬ ┬
 	├─┘ │ └┬┘
-	┴   ┴  ┴ `,
+	┴   ┴  ┴
+  `+"DMSG pseudoterminal (pty)",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,

--- a/cmd/dmsg/dmsg.go
+++ b/cmd/dmsg/dmsg.go
@@ -63,7 +63,7 @@ var dmsgptyCmd = &cobra.Command{
 	┌─┐┌┬┐┬ ┬
 	├─┘ │ └┬┘
 	┴   ┴  ┴
-  `+"DMSG pseudoterminal (pty)",
+  ` + "DMSG pseudoterminal (pty)",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,

--- a/cmd/dmsgcurl/commands/dmsgcurl.go
+++ b/cmd/dmsgcurl/commands/dmsgcurl.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
@@ -60,21 +59,17 @@ func init() {
 		sk.Set(os.Getenv("DMSGCURL_SK")) //nolint
 	}
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgcurl")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
 }
 
 // RootCmd containsa the root dmsgcurl command
 var RootCmd = &cobra.Command{
-	Short: "dmsgcurl",
+	Short: "DMSG curl utility",
 	Use:   "dmsgcurl [OPTIONS] ... [URL]",
 	Long: `
-	┌┬┐┌┬┐┌─┐┌─┐┌─┐┬ ┬┬─┐┬  
-	 │││││└─┐│ ┬│  │ │├┬┘│  
-	─┴┘┴ ┴└─┘└─┘└─┘└─┘┴└─┴─┘`,
+	┌┬┐┌┬┐┌─┐┌─┐┌─┐┬ ┬┬─┐┬
+	 │││││└─┐│ ┬│  │ │├┬┘│
+	─┴┘┴ ┴└─┘└─┘└─┘└─┘┴└─┴─┘
+  ` + "DMSG curl utility",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -359,30 +354,7 @@ func (pw *ProgressWriter) Write(p []byte) (int, error) {
 
 // Execute executes root CLI command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgcurl/dmsgcurl.go
+++ b/cmd/dmsgcurl/dmsgcurl.go
@@ -1,8 +1,45 @@
 // package main cmd/dmsgcurl/dmsgcurl.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsgcurl/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsgcurl/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-cli")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsghttp/commands/dmsghttp.go
+++ b/cmd/dmsghttp/commands/dmsghttp.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/cmdutil"
@@ -44,21 +43,18 @@ func init() {
 		sk.Set(os.Getenv("DMSGHTTP_SK")) //nolint
 	}
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsghttp")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
+
 }
 
 // RootCmd contains the root dmsghttp command
 var RootCmd = &cobra.Command{
 	Use:   "http",
-	Short: "dmsghttp file server",
+	Short: "DMSG http file server",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐┬ ┬┌┬┐┌┬┐┌─┐
 	 │││││└─┐│ ┬├─┤ │  │ ├─┘
-	─┴┘┴ ┴└─┘└─┘┴ ┴ ┴  ┴ ┴  `,
+	─┴┘┴ ┴└─┘└─┘┴ ┴ ┴  ┴ ┴
+  ` + "DMSG http file server",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -190,30 +186,7 @@ func fileServerHandler(w http.ResponseWriter, r *http.Request) {
 
 // Execute executes root CLI command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsghttp/dmsghttp.go
+++ b/cmd/dmsghttp/dmsghttp.go
@@ -1,8 +1,44 @@
 // package main cmd/dmsg-discovery/dmsg-discovery.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsghttp/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsghttp/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-cli")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -30,10 +30,9 @@ var (
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringVar(&cli.Net, "clinet", cli.Net, "network to use for dialing to dmsgpty-host")
-	RootCmd.PersistentFlags().StringVar(&cli.Addr, "cliaddr", cli.Addr, "address to use for dialing to dmsgpty-host")
-	RootCmd.PersistentFlags().StringVarP(&confPath, "confpath", confPath, defaultConfPath, "config path")
-	cobra.OnInitialize(initConfig)
+	RootCmd.Flags().StringVarP(&cli.Net, "clinet", "n", cli.Net, "network to use for dialing to dmsgpty-host")
+	RootCmd.Flags().StringVarP(&cli.Addr, "cliaddr", "r", cli.Addr, "address to use for dialing to dmsgpty-host")
+	RootCmd.Flags().StringVarP(&confPath, "confpath", "p", defaultConfPath, "config path")
 	RootCmd.Flags().Var(&remoteAddr, "addr", "remote dmsg address of format 'pk:port'\n If unspecified, the pty will start locally\n")
 	RootCmd.Flags().StringVarP(&cmdName, "cmd", "c", cmdName, "name of command to run\n")
 	RootCmd.Flags().StringSliceVarP(&cmdArgs, "args", "a", cmdArgs, "command arguments")
@@ -57,6 +56,50 @@ var RootCmd = &cobra.Command{
 	DisableSuggestions:    true,
 	DisableFlagsInUseLine: true,
 	PreRun: func(*cobra.Command, []string) {
+		// source whitelist from config file
+		// by default : it will look for config
+		//
+		// case 1 : config file is new (does not contain a "wl" key)
+		// - create a "wl" key within the config file
+		//
+		// case 2 : config file is old (already contains "wl" key)
+		// - load config file into memory to manipulate whitelists
+		// - writes changes back to config file
+			println(confPath)
+
+			if _, err := os.Stat(confPath); err != nil {
+				cli.Log.Fatalf("Config file %s not found.", confPath)
+			}
+
+			// read file using ioutil
+			file, err := os.ReadFile(confPath) //nolint:gosec
+			if err != nil {
+				cli.Log.Fatalln("Unable to read ", confPath, err)
+			}
+
+			// store config.json into conf to manipulate whitelists
+			err = json.Unmarshal(file, &conf)
+			if err != nil {
+				cli.Log.Errorln(err)
+				// ignoring this error
+				b, err := json.MarshalIndent(conf, "", "  ")
+				if err != nil {
+					cli.Log.Fatalln("Unable to marshal conf")
+				}
+
+				// write to config.json
+				err = os.WriteFile(confPath, b, 0600)
+				if err != nil {
+					cli.Log.Fatalln("Unable to write", confPath, err)
+				}
+			}
+			conf.CLIAddr = dmsgpty.ParseWindowsEnv(conf.CLIAddr)
+			if conf.CLIAddr != "" {
+				cli.Addr = conf.CLIAddr
+			}
+			if conf.CLINet != "" {
+				cli.Net = conf.CLINet
+			}
 		if remoteAddr.Port == 0 {
 			remoteAddr.Port = dmsgpty.DefaultPort
 		}
@@ -107,51 +150,3 @@ const help = "Usage:\r\n" +
 	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
 	"Global Flags:\r\n" +
 	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"
-
-// initConfig sources whitelist from config file
-// by default : it will look for config
-//
-// case 1 : config file is new (does not contain a "wl" key)
-// - create a "wl" key within the config file
-//
-// case 2 : config file is old (already contains "wl" key)
-// - load config file into memory to manipulate whitelists
-// - writes changes back to config file
-func initConfig() {
-
-	println(confPath)
-
-	if _, err := os.Stat(confPath); err != nil {
-		cli.Log.Fatalf("Config file %s not found.", confPath)
-	}
-
-	// read file using ioutil
-	file, err := os.ReadFile(confPath) //nolint:gosec
-	if err != nil {
-		cli.Log.Fatalln("Unable to read ", confPath, err)
-	}
-
-	// store config.json into conf to manipulate whitelists
-	err = json.Unmarshal(file, &conf)
-	if err != nil {
-		cli.Log.Errorln(err)
-		// ignoring this error
-		b, err := json.MarshalIndent(conf, "", "  ")
-		if err != nil {
-			cli.Log.Fatalln("Unable to marshal conf")
-		}
-
-		// write to config.json
-		err = os.WriteFile(confPath, b, 0600)
-		if err != nil {
-			cli.Log.Fatalln("Unable to write", confPath, err)
-		}
-	}
-	conf.CLIAddr = dmsgpty.ParseWindowsEnv(conf.CLIAddr)
-	if conf.CLIAddr != "" {
-		cli.Addr = conf.CLIAddr
-	}
-	if conf.CLINet != "" {
-		cli.Net = conf.CLINet
-	}
-}

--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -65,41 +65,41 @@ var RootCmd = &cobra.Command{
 		// case 2 : config file is old (already contains "wl" key)
 		// - load config file into memory to manipulate whitelists
 		// - writes changes back to config file
-			println(confPath)
+		println(confPath)
 
-			if _, err := os.Stat(confPath); err != nil {
-				cli.Log.Fatalf("Config file %s not found.", confPath)
-			}
+		if _, err := os.Stat(confPath); err != nil {
+			cli.Log.Fatalf("Config file %s not found.", confPath)
+		}
 
-			// read file using ioutil
-			file, err := os.ReadFile(confPath) //nolint:gosec
+		// read file using ioutil
+		file, err := os.ReadFile(confPath) //nolint:gosec
+		if err != nil {
+			cli.Log.Fatalln("Unable to read ", confPath, err)
+		}
+
+		// store config.json into conf to manipulate whitelists
+		err = json.Unmarshal(file, &conf)
+		if err != nil {
+			cli.Log.Errorln(err)
+			// ignoring this error
+			b, err := json.MarshalIndent(conf, "", "  ")
 			if err != nil {
-				cli.Log.Fatalln("Unable to read ", confPath, err)
+				cli.Log.Fatalln("Unable to marshal conf")
 			}
 
-			// store config.json into conf to manipulate whitelists
-			err = json.Unmarshal(file, &conf)
+			// write to config.json
+			err = os.WriteFile(confPath, b, 0600)
 			if err != nil {
-				cli.Log.Errorln(err)
-				// ignoring this error
-				b, err := json.MarshalIndent(conf, "", "  ")
-				if err != nil {
-					cli.Log.Fatalln("Unable to marshal conf")
-				}
-
-				// write to config.json
-				err = os.WriteFile(confPath, b, 0600)
-				if err != nil {
-					cli.Log.Fatalln("Unable to write", confPath, err)
-				}
+				cli.Log.Fatalln("Unable to write", confPath, err)
 			}
-			conf.CLIAddr = dmsgpty.ParseWindowsEnv(conf.CLIAddr)
-			if conf.CLIAddr != "" {
-				cli.Addr = conf.CLIAddr
-			}
-			if conf.CLINet != "" {
-				cli.Net = conf.CLINet
-			}
+		}
+		conf.CLIAddr = dmsgpty.ParseWindowsEnv(conf.CLIAddr)
+		if conf.CLIAddr != "" {
+			cli.Addr = conf.CLIAddr
+		}
+		if conf.CLINet != "" {
+			cli.Net = conf.CLINet
+		}
 		if remoteAddr.Port == 0 {
 			remoteAddr.Port = dmsgpty.DefaultPort
 		}

--- a/cmd/dmsgpty-cli/commands/root.go
+++ b/cmd/dmsgpty-cli/commands/root.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -36,21 +35,17 @@ func init() {
 	RootCmd.Flags().Var(&remoteAddr, "addr", "remote dmsg address of format 'pk:port'\n If unspecified, the pty will start locally\n")
 	RootCmd.Flags().StringVarP(&cmdName, "cmd", "c", cmdName, "name of command to run\n")
 	RootCmd.Flags().StringSliceVarP(&cmdArgs, "args", "a", cmdArgs, "command arguments")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-cli")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
 }
 
 // RootCmd contains commands for dmsgpty-cli; which interacts with the dmsgpty-host instance (i.e. skywire-visor)
 var RootCmd = &cobra.Command{
 	Use:   "cli",
-	Short: "Run commands over dmsg",
+	Short: "DMSG pseudoterminal command line interface",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐┌─┐┌┬┐┬ ┬   ┌─┐┬  ┬
 	 │││││└─┐│ ┬├─┘ │ └┬┘───│  │  │
-	─┴┘┴ ┴└─┘└─┘┴   ┴  ┴    └─┘┴─┘┴`,
+	─┴┘┴ ┴└─┘└─┘┴   ┴  ┴    └─┘┴─┘┴
+  ` + "DMSG pseudoterminal command line interface",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -123,30 +118,7 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgpty-cli/dmsgpty-cli.go
+++ b/cmd/dmsgpty-cli/dmsgpty-cli.go
@@ -1,8 +1,44 @@
 // package main cmd/dmsgpty-cli/dmsgpty-cli.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsgpty-cli/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsgpty-cli/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-cli")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgpty-host/commands/root.go
+++ b/cmd/dmsgpty-host/commands/root.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
@@ -56,31 +55,28 @@ var (
 func init() {
 
 	// Prepare flags with env/config references.
-	RootCmd.PersistentFlags().Var(&wl, "wl", "whitelist of the dmsgpty-host")
-	RootCmd.PersistentFlags().StringVar(&dmsgDisc, "dmsgdisc", dmsgDisc, "dmsg discovery address")
-	RootCmd.PersistentFlags().IntVar(&dmsgSessions, "dmsgsessions", dmsgSessions, "minimum number of dmsg sessions to ensure")
-	RootCmd.PersistentFlags().Uint16Var(&dmsgPort, "dmsgport", dmsgPort, "dmsg port for listening for remote hosts")
-	RootCmd.PersistentFlags().StringVar(&cliNet, "clinet", cliNet, "network used for listening for cli connections")
-	RootCmd.PersistentFlags().StringVar(&cliAddr, "cliaddr", cliAddr, "address used for listening for cli connections")
+	RootCmd.Flags().Var(&wl, "wl", "whitelist of the dmsgpty-host")
+	RootCmd.Flags().StringVar(&dmsgDisc, "dmsgdisc", dmsgDisc, "dmsg discovery address")
+	RootCmd.Flags().IntVar(&dmsgSessions, "dmsgsessions", dmsgSessions, "minimum number of dmsg sessions to ensure")
+	RootCmd.Flags().Uint16Var(&dmsgPort, "dmsgport", dmsgPort, "dmsg port for listening for remote hosts")
+	RootCmd.Flags().StringVar(&cliNet, "clinet", cliNet, "network used for listening for cli connections")
+	RootCmd.Flags().StringVar(&cliAddr, "cliaddr", cliAddr, "address used for listening for cli connections")
 	// Prepare flags without associated env/config references.
-	RootCmd.PersistentFlags().StringVar(&envPrefix, "envprefix", envPrefix, "env prefix")
+	RootCmd.Flags().StringVar(&envPrefix, "envprefix", envPrefix, "env prefix")
 	RootCmd.Flags().BoolVar(&confStdin, "confstdin", confStdin, "config will be read from stdin if set")
 	RootCmd.Flags().StringVarP(&confPath, "confpath", "c", confPath, "config path")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-host")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
+
 }
 
 // RootCmd contains commands for dmsgpty-host
 var RootCmd = &cobra.Command{
 	Use:   "host",
-	Short: "runs a standalone dmsgpty-host instance",
+	Short: "DMSG host for pseudoterminal command line interface",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐┌─┐┌┬┐┬ ┬   ┬ ┬┌─┐┌─┐┌┬┐
 	 │││││└─┐│ ┬├─┘ │ └┬┘───├─┤│ │└─┐ │
-	─┴┘┴ ┴└─┘└─┘┴   ┴  ┴    ┴ ┴└─┘└─┘ ┴ `,
+	─┴┘┴ ┴└─┘└─┘┴   ┴  ┴    ┴ ┴└─┘└─┘ ┴
+  ` + "DMSG host for pseudoterminal command line interface",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -158,33 +154,10 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"
 
 func configFromJSON(conf dmsgpty.Config) (dmsgpty.Config, error) {
 	var jsonConf dmsgpty.Config

--- a/cmd/dmsgpty-host/dmsgpty-host.go
+++ b/cmd/dmsgpty-host/dmsgpty-host.go
@@ -1,8 +1,45 @@
 // Package main cmd/dmsgpty-host/dmsgpty-host.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsgpty-host/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsgpty-host/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-host")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
+
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgpty-ui/commands/dmsgpty-ui.go
+++ b/cmd/dmsgpty-ui/commands/dmsgpty-ui.go
@@ -70,13 +70,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgpty-ui/commands/dmsgpty-ui.go
+++ b/cmd/dmsgpty-ui/commands/dmsgpty-ui.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/sirupsen/logrus"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/spf13/cobra"
@@ -23,26 +22,22 @@ var (
 )
 
 func init() {
-	RootCmd.PersistentFlags().StringVar(&hostNet, "hnet", hostNet, "dmsgpty host network name")
-	RootCmd.PersistentFlags().StringVar(&hostAddr, "haddr", hostAddr, "dmsgpty host network address")
-	RootCmd.PersistentFlags().StringVar(&addr, "addr", addr, "network address to serve UI on")
-	RootCmd.PersistentFlags().StringVar(&conf.CmdName, "cmd", conf.CmdName, "command to run when initiating pty")
-	RootCmd.PersistentFlags().StringArrayVar(&conf.CmdArgs, "arg", conf.CmdArgs, "command arguments to include when initiating pty")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-ui")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
+	RootCmd.Flags().StringVar(&hostNet, "hnet", hostNet, "dmsgpty host network name")
+	RootCmd.Flags().StringVar(&hostAddr, "haddr", hostAddr, "dmsgpty host network address")
+	RootCmd.Flags().StringVar(&addr, "addr", addr, "network address to serve UI on")
+	RootCmd.Flags().StringVar(&conf.CmdName, "cmd", conf.CmdName, "command to run when initiating pty")
+	RootCmd.Flags().StringArrayVar(&conf.CmdArgs, "arg", conf.CmdArgs, "command arguments to include when initiating pty")
 }
 
 // RootCmd contains commands to start a dmsgpty-ui server for a dmsgpty-host
 var RootCmd = &cobra.Command{
 	Use:   "ui",
-	Short: "hosts a UI server for a dmsgpty-host",
+	Short: "DMSG pseudoterminal GUI",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐┌─┐┌┬┐┬ ┬   ┬ ┬┬
 	 │││││└─┐│ ┬├─┘ │ └┬┘───│ ││
-	─┴┘┴ ┴└─┘└─┘┴   ┴  ┴    └─┘┴`,
+	─┴┘┴ ┴└─┘└─┘┴   ┴  ┴    └─┘┴
+  ` + "DMSG pseudoterminal GUI",
 	Run: func(cmd *cobra.Command, args []string) {
 		if _, err := buildinfo.Get().WriteTo(log.Writer()); err != nil {
 			log.Printf("Failed to output build info: %v", err)
@@ -71,19 +66,6 @@ var RootCmd = &cobra.Command{
 
 // Execute executes the root command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/dmsgpty-ui/dmsgpty-ui.go
+++ b/cmd/dmsgpty-ui/dmsgpty-ui.go
@@ -1,8 +1,44 @@
 // Package main cmd/dmsgpty-ui/dmsgpty-ui.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsgpty-ui/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsgpty-ui/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgpty-ui")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsgweb/commands/dmsgweb.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/confiant-inc/go-socks5"
 	"github.com/gin-gonic/gin"
-	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/skycoin/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire-utilities/pkg/cmdutil"
@@ -89,21 +88,17 @@ func init() {
 		sk.Set(os.Getenv("DMSGGET_SK")) //nolint
 	}
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
-	var helpflag bool
-	RootCmd.SetUsageTemplate(help)
-	RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgweb")
-	RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
-	RootCmd.PersistentFlags().MarkHidden("help") //nolint
 }
 
 // RootCmd contains the root command for dmsgweb
 var RootCmd = &cobra.Command{
-	Use:   "dmsgweb",
-	Short: "access websites over dmsg",
+	Use:   "web",
+	Short: "DMSG resolving proxy & browser client",
 	Long: `
 	┌┬┐┌┬┐┌─┐┌─┐┬ ┬┌─┐┌┐
 	 │││││└─┐│ ┬│││├┤ ├┴┐
-	─┴┘┴ ┴└─┘└─┘└┴┘└─┘└─┘`,
+	─┴┘┴ ┴└─┘└─┘└┴┘└─┘└─┘
+  ` + "DMSG resolving proxy & browser client - access websites over dmsg",
 	SilenceErrors:         true,
 	SilenceUsage:          true,
 	DisableSuggestions:    true,
@@ -363,30 +358,7 @@ const (
 
 // Execute executes root CLI command.
 func Execute() {
-	cc.Init(&cc.Config{
-		RootCmd:       RootCmd,
-		Headings:      cc.HiBlue + cc.Bold, //+ cc.Underline,
-		Commands:      cc.HiBlue + cc.Bold,
-		CmdShortDescr: cc.HiBlue,
-		Example:       cc.HiBlue + cc.Italic,
-		ExecName:      cc.HiBlue + cc.Bold,
-		Flags:         cc.HiBlue + cc.Bold,
-		//FlagsDataType: cc.HiBlue,
-		FlagsDescr:      cc.HiBlue,
-		NoExtraNewlines: true,
-		NoBottomNewline: true,
-	})
 	if err := RootCmd.Execute(); err != nil {
 		log.Fatal("Failed to execute command: ", err)
 	}
 }
-
-const help = "Usage:\r\n" +
-	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
-	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
-	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
-	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
-	"Flags:\r\n" +
-	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
-	"Global Flags:\r\n" +
-	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"

--- a/cmd/dmsgweb/dmsgweb.go
+++ b/cmd/dmsgweb/dmsgweb.go
@@ -1,8 +1,44 @@
 // Package main cmd/dmsgweb/dmsgweb.go
 package main
 
-import "github.com/skycoin/dmsg/cmd/dmsgweb/commands"
+import (
+	cc "github.com/ivanpirog/coloredcobra"
+	"github.com/spf13/cobra"
+
+	"github.com/skycoin/dmsg/cmd/dmsgweb/commands"
+)
+
+func init() {
+	var helpflag bool
+	commands.RootCmd.SetUsageTemplate(help)
+	commands.RootCmd.PersistentFlags().BoolVarP(&helpflag, "help", "h", false, "help for dmsgweb")
+	commands.RootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+	commands.RootCmd.PersistentFlags().MarkHidden("help") //nolint
+}
 
 func main() {
+	cc.Init(&cc.Config{
+		RootCmd:       commands.RootCmd,
+		Headings:      cc.HiBlue + cc.Bold,
+		Commands:      cc.HiBlue + cc.Bold,
+		CmdShortDescr: cc.HiBlue,
+		Example:       cc.HiBlue + cc.Italic,
+		ExecName:      cc.HiBlue + cc.Bold,
+		Flags:         cc.HiBlue + cc.Bold,
+		//FlagsDataType: cc.HiBlue,
+		FlagsDescr:      cc.HiBlue,
+		NoExtraNewlines: true,
+		NoBottomNewline: true,
+	})
 	commands.Execute()
 }
+
+const help = "Usage:\r\n" +
+	"  {{.UseLine}}{{if .HasAvailableSubCommands}}{{end}} {{if gt (len .Aliases) 0}}\r\n\r\n" +
+	"{{.NameAndAliases}}{{end}}{{if .HasAvailableSubCommands}}\r\n\r\n" +
+	"Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand)}}\r\n  " +
+	"{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}\r\n\r\n" +
+	"Flags:\r\n" +
+	"{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}\r\n\r\n" +
+	"Global Flags:\r\n" +
+	"{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}\r\n\r\n"


### PR DESCRIPTION
* move config parsing out of init because it messes up other sub-commands when dmsgpty-cli is included as a sub-command
* revise all commands to move modification of the help menus and color initialization to their respective wrappers, to allow customization on import instead of having colors not working right on import (skywire/cmd/skywire-deployment)