### PR TITLE
add heartbeat logic to dmsg clients

### DIFF
--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -153,6 +153,8 @@ func (ce *Client) Serve(ctx context.Context) {
 		}
 	}(cancellabelCtx)
 
+	updateEntryLoopOnce := new(sync.Once)
+
 	for {
 		if isClosed(ce.done) {
 			return
@@ -253,6 +255,10 @@ func (ce *Client) Serve(ctx context.Context) {
 				ce.serveWait()
 			}
 		}
+
+		// Only start the update entry loop once we have at least one session established.
+		updateEntryLoopOnce.Do(func() { go ce.updateClientEntryLoop(cancellabelCtx, ce.done, ce.conf.ClientType) })
+
 		// We dial all servers and wait for error or done signal.
 		select {
 		case <-ce.done:

--- a/pkg/dmsg/client.go
+++ b/pkg/dmsg/client.go
@@ -60,7 +60,7 @@ func (c *Config) Ensure() {
 func DefaultConfig() *Config {
 	conf := &Config{
 		MinSessions:    DefaultMinSessions,
-		UpdateInterval: DefaultUpdateInterval,
+		UpdateInterval: DefaultUpdateInterval * 5,
 	}
 	return conf
 }


### PR DESCRIPTION
Fixes Part of https://github.com/skycoin/skywire-services/issues/63

 Changes:	
- add heartbeat logic to dmsg client for each 5 minutes

How to test this PR:
Check here https://github.com/skycoin/skywire/pull/1821