### PR TITLE
User specified dmsghttp-config

### DIFF
--- a/cmd/dmsg-socks5/commands/dmsg-socks5.go
+++ b/cmd/dmsg-socks5/commands/dmsg-socks5.go
@@ -36,6 +36,8 @@ var (
 	httpClient   *http.Client
 	dmsgSessions int
 	dlog         *logging.Logger
+	dmsgHTTPPath string
+	err          error
 )
 
 // Execute executes root CLI command.
@@ -50,24 +52,26 @@ func init() {
 		proxyCmd,
 	)
 
-	serveCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to serve socks5")
-	serveCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated")
-	serveCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url")
-	serveCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
+	serveCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to serve socks5\033[0m\n\r")
+	serveCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated\033[0m\n\r")
+	serveCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
+	serveCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
+	serveCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
 	if os.Getenv("DMSGSK") != "" {
 		sk.Set(os.Getenv("DMSGSK")) //nolint
 	}
-	serveCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
+	serveCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
 
-	proxyCmd.Flags().IntVarP(&proxyPort, "port", "p", 1081, "TCP port to serve SOCKS5 proxy locally")
-	proxyCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to connect to socks5 server")
-	proxyCmd.Flags().StringVarP(&pubk, "pk", "k", "", "dmsg socks5 proxy server public key to connect to")
-	proxyCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url")
-	proxyCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
+	proxyCmd.Flags().IntVarP(&proxyPort, "port", "p", 1081, "TCP port to serve SOCKS5 proxy locally\033[0m\n\r")
+	proxyCmd.Flags().Uint16VarP(&dmsgPort, "dport", "q", 1081, "dmsg port to connect to socks5 server\033[0m\n\r")
+	proxyCmd.Flags().StringVarP(&pubk, "pk", "k", "", "dmsg socks5 proxy server public key to connect to\033[0m\n\r")
+	proxyCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
+	proxyCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
+	proxyCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
 	if os.Getenv("DMSGSK") != "" {
 		sk.Set(os.Getenv("DMSGSK")) //nolint
 	}
-	proxyCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
+	proxyCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
 
 }
 
@@ -104,6 +108,18 @@ var serveCmd = &cobra.Command{
 			dlog.Info("Interrupt received. Shutting down...")
 			os.Exit(0)
 		}()
+
+		if dmsgHTTPPath != "" {
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+			}
+			err = dmsg.InitConfig()
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
+			}
+		}
+
 		pk, err := sk.PubKey()
 		if err != nil {
 			pk, sk = cipher.GenerateKeyPair()
@@ -197,6 +213,18 @@ var proxyCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(_ *cobra.Command, _ []string) {
 		dlog = logging.MustGetLogger("dmsg-proxy-client")
+
+		if dmsgHTTPPath != "" {
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+			}
+			err = dmsg.InitConfig()
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
+			}
+		}
+
 		var pubKey cipher.PubKey
 		err := pubKey.Set(pubk)
 		if err != nil {

--- a/cmd/dmsg-socks5/commands/dmsg-socks5.go
+++ b/cmd/dmsg-socks5/commands/dmsg-socks5.go
@@ -110,7 +110,7 @@ var serveCmd = &cobra.Command{
 		}()
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}
@@ -215,7 +215,7 @@ var proxyCmd = &cobra.Command{
 		dlog = logging.MustGetLogger("dmsg-proxy-client")
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}

--- a/cmd/dmsgcurl/commands/dmsgcurl.go
+++ b/cmd/dmsgcurl/commands/dmsgcurl.go
@@ -91,7 +91,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}

--- a/cmd/dmsgcurl/commands/dmsgcurl.go
+++ b/cmd/dmsgcurl/commands/dmsgcurl.go
@@ -36,6 +36,7 @@ var (
 	dmsgSessions   int
 	dmsgcurlData   string
 	sk             cipher.SecKey
+	pk             cipher.PubKey
 	dlog           = logging.MustGetLogger("dmsgcurl")
 	dmsgcurlAgent  string
 	logLvl         string
@@ -48,6 +49,7 @@ var (
 	dialer         = proxy.Direct //nolint unused
 	dmsgHTTPPath   string
 	useHTTP        bool
+	err            error
 )
 
 func init() {
@@ -87,7 +89,19 @@ var RootCmd = &cobra.Command{
 				logging.SetLevel(lvl)
 			}
 		}
-		pk, err := sk.PubKey()
+
+		if dmsgHTTPPath != "" {
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+			}
+			err = dmsg.InitConfig()
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
+			}
+		}
+
+		pk, err = sk.PubKey()
 		if err != nil {
 			pk, sk = cipher.GenerateKeyPair()
 		}

--- a/cmd/dmsghttp/commands/dmsghttp.go
+++ b/cmd/dmsghttp/commands/dmsghttp.go
@@ -45,15 +45,14 @@ var (
 
 func init() {
 	RootCmd.Flags().SortFlags = false
-	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
-	//RootCmd.Flags().StringSliceVarP(&dmsgDiscs, "dmsg-disc", "c", []string{dmsg.DiscAddr(false)}, "dmsg discovery url(s)\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", proxyAddr, "connect to dmsg via proxy (i.e. '127.0.0.1:1080')\033[0m\n\r")
+	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
+	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
+	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", proxyAddr, "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", 1, "number of dmsg servers to connect to\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&serveDir, "dir", "r", ".", "local dir to serve via dmsghttp\033[0m\n\r")
 	RootCmd.Flags().UintVarP(&dmsgPort, "port", "d", 80, "dmsg port to serve from\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys to access server, comma separated")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
 	if os.Getenv("DMSGHTTP_SK") != "" {
 		sk.Set(os.Getenv("DMSGHTTP_SK")) //nolint

--- a/cmd/dmsghttp/commands/dmsghttp.go
+++ b/cmd/dmsghttp/commands/dmsghttp.go
@@ -87,7 +87,7 @@ func server() {
 	log := logging.MustGetLogger("dmsghttp")
 
 	if dmsgHTTPPath != "" {
-		dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+		dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 		if err != nil {
 			dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 		}

--- a/cmd/dmsghttp/commands/dmsghttp.go
+++ b/cmd/dmsghttp/commands/dmsghttp.go
@@ -45,16 +45,16 @@ var (
 
 func init() {
 	RootCmd.Flags().SortFlags = false
-	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
+	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
 	//RootCmd.Flags().StringSliceVarP(&dmsgDiscs, "dmsg-disc", "c", []string{dmsg.DiscAddr(false)}, "dmsg discovery url(s)\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
-	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", proxyAddr, "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
+	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", proxyAddr, "connect to dmsg via proxy (i.e. '127.0.0.1:1080')\033[0m\n\r")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", 1, "number of dmsg servers to connect to\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&serveDir, "dir", "r", ".", "local dir to serve via dmsghttp")
-	RootCmd.Flags().UintVarP(&dmsgPort, "port", "d", 80, "dmsg port to serve from")
-	RootCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated")
-	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url")
+	RootCmd.Flags().StringVarP(&serveDir, "dir", "r", ".", "local dir to serve via dmsghttp\033[0m\n\r")
+	RootCmd.Flags().UintVarP(&dmsgPort, "port", "d", 80, "dmsg port to serve from\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&wl, "wl", "w", "", "whitelist keys, comma separated\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
 	if os.Getenv("DMSGHTTP_SK") != "" {
 		sk.Set(os.Getenv("DMSGHTTP_SK")) //nolint
 	}
@@ -85,7 +85,18 @@ func server() {
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
 
-	log := logging.MustGetLogger("dmsgvlc")
+	log := logging.MustGetLogger("dmsghttp")
+
+	if dmsgHTTPPath != "" {
+		dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+		if err != nil {
+			dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+		}
+		err = dmsg.InitConfig()
+		if err != nil {
+			dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
+		}
+	}
 
 	pk, err = sk.PubKey()
 	if err != nil {

--- a/cmd/dmsgip/commands/dmsgip.go
+++ b/cmd/dmsgip/commands/dmsgip.go
@@ -31,10 +31,13 @@ var (
 	httpClient   *http.Client
 	useHTTP      bool
 	dmsgSessions int
+	dmsgHTTPPath string
+	err          error
 )
 
 func init() {
 	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
+	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "c", dmsgDisc, "dmsg discovery url\033[0m")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", 1, "number of dmsg servers to connect to\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
@@ -65,6 +68,17 @@ var RootCmd = &cobra.Command{
 		if logLvl != "" {
 			if lvl, err := logging.LevelFromString(logLvl); err == nil {
 				logging.SetLevel(lvl)
+			}
+		}
+
+		if dmsgHTTPPath != "" {
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+			}
+			err = dmsg.InitConfig()
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
 			}
 		}
 

--- a/cmd/dmsgip/commands/dmsgip.go
+++ b/cmd/dmsgip/commands/dmsgip.go
@@ -72,7 +72,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}

--- a/cmd/dmsgip/commands/dmsgip.go
+++ b/cmd/dmsgip/commands/dmsgip.go
@@ -37,15 +37,15 @@ var (
 
 func init() {
 	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
-	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "c", dmsgDisc, "dmsg discovery url\033[0m")
+	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
+	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "c", dmsgDisc, "dmsg discovery url\033[0m\n\r")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", 1, "number of dmsg servers to connect to\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "p", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
-	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m")
+	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "fatal", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
 	if os.Getenv("DMSGIP_SK") != "" {
 		sk.Set(os.Getenv("DMSGIP_SK")) //nolint
 	}
-	RootCmd.Flags().StringSliceVarP(&dmsgServers, "srv", "d", []string{}, "dmsg server public keys\n\r\033[0m")
+	RootCmd.Flags().StringSliceVarP(&dmsgServers, "srv", "d", []string{}, "dmsg server public keys")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r\033[0m")
 }
 

--- a/cmd/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsgweb/commands/dmsgweb.go
@@ -78,7 +78,12 @@ func init() {
 	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", dmsgSess, "number of dmsg servers to connect to\033[0m\n\r")
-	RootCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP")
+	RootCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP, comma separated"+func() string {
+		if len(rawTCP) > 0 {
+			return "\033[0m\n\r"
+		}
+		return ""
+	}())
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
 	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "Z", false, "show example .conf file")

--- a/cmd/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsgweb/commands/dmsgweb.go
@@ -68,18 +68,19 @@ func init() {
 	}
 	pk, _ = sk.PubKey() //nolint
 
-	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
+	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&filterDomainSuffix, "filter", "f", ".dmsg", "domain suffix to filter\033[0m\n\r")
 	RootCmd.Flags().UintVarP(&proxyPort, "socks", "q", proxyPort, "port to serve the socks5 proxy\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&addProxy, "addproxy", "r", addProxy, "configure additional socks5 proxy for dmsgweb (i.e. 127.0.0.1:1080)\033[0m\n\r")
 	RootCmd.Flags().UintSliceVarP(&webPort, "port", "p", webPort, "port(s) to serve the web application\033[0m\n\r")
 	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port & disable proxy\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')\033[0m\n\r")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", dmsgSess, "number of dmsg servers to connect to\033[0m\n\r")
 	RootCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
-	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
+	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
 	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "Z", false, "show example .conf file\033[0m\n\r")
 
 }
@@ -117,6 +118,17 @@ dmsgweb conf file detected: ` + dwcfg
 		dlog = logging.MustGetLogger("dmsgweb")
 		if dmsgDisc == "" {
 			dlog.Fatal("Dmsg Discovery URL not specified")
+		}
+
+		if dmsgHTTPPath != "" {
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+			}
+			err = dmsg.InitConfig()
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
+			}
 		}
 
 		if len(resolveDmsgAddr) > 0 && len(webPort) != len(resolveDmsgAddr) {

--- a/cmd/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsgweb/commands/dmsgweb.go
@@ -68,20 +68,20 @@ func init() {
 	}
 	pk, _ = sk.PubKey() //nolint
 
-	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery\033[0m\n\r")
+	RootCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
 	RootCmd.Flags().StringVarP(&filterDomainSuffix, "filter", "f", ".dmsg", "domain suffix to filter\033[0m\n\r")
 	RootCmd.Flags().UintVarP(&proxyPort, "socks", "q", proxyPort, "port to serve the socks5 proxy\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&addProxy, "addproxy", "r", addProxy, "configure additional socks5 proxy for dmsgweb (i.e. 127.0.0.1:1080)\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&addProxy, "addproxy", "r", addProxy, "configure additional socks5 proxy for dmsgweb (i.e. 127.0.0.1:1080)")
 	RootCmd.Flags().UintSliceVarP(&webPort, "port", "p", webPort, "port(s) to serve the web application\033[0m\n\r")
-	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port & disable proxy\033[0m\n\r")
+	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port & disable proxy")
 	RootCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "dmsg discovery url\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
-	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')\033[0m\n\r")
+	RootCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
+	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to dmsg via proxy (i.e. '127.0.0.1:1080')")
 	RootCmd.Flags().IntVarP(&dmsgSessions, "sess", "e", dmsgSess, "number of dmsg servers to connect to\033[0m\n\r")
-	RootCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP\033[0m\n\r")
+	RootCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
-	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "Z", false, "show example .conf file\033[0m\n\r")
+	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "Z", false, "show example .conf file")
 
 }
 

--- a/cmd/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsgweb/commands/dmsgweb.go
@@ -126,7 +126,7 @@ dmsgweb conf file detected: ` + dwcfg
 		}
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}

--- a/cmd/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsgweb/commands/dmsgwebsrv.go
@@ -46,14 +46,24 @@ func init() {
 	srvCmd.Flags().BoolVarP(&useHTTP, "http", "z", false, "use regular http to connect to dmsg discovery")
 	srvCmd.Flags().UintSliceVarP(&localPort, "lport", "p", localPort, "local application interface port(s)\033[0m\n\r")
 	srvCmd.Flags().UintSliceVarP(&dmsgPort, "dport", "d", dmsgPort, "DMSG port(s) to serve\033[0m\n\r")
-	srvCmd.Flags().StringSliceVarP(&wl, "wl", "w", wl, "whitelisted keys for DMSG authenticated routes\033[0m\n\r")
+	srvCmd.Flags().StringSliceVarP(&wl, "wl", "w", wl, "whitelisted keys for DMSG authenticated routes"+func() string {
+		if len(wl) > 0 {
+			return "\033[0m\n\r"
+		}
+		return ""
+	}())
 	srvCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "DMSG discovery URL\033[0m\n\r")
-	srvCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
-	srvCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", proxyAddr, "connect to DMSG via proxy (e.g., '127.0.0.1:1080')\033[0m\n\r")
+	srvCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path")
+	srvCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", proxyAddr, "connect to DMSG via proxy (e.g., '127.0.0.1:1080')")
 	srvCmd.Flags().IntVarP(&dmsgSess, "dsess", "e", dmsgSess, "DMSG sessions\033[0m\n\r")
-	srvCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP, comma separated\033[0m\n\r")
+	srvCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP, comma separated"+func() string {
+		if len(rawTCP) > 0 {
+			return "\033[0m\n\r"
+		}
+		return ""
+	}())
 	srvCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
-	srvCmd.Flags().BoolVarP(&isEnvs, "envs", "Z", false, "show example .conf file\033[0m\n\r")
+	srvCmd.Flags().BoolVarP(&isEnvs, "envs", "Z", false, "show example .conf file")
 	srvCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
 	srvCmd.CompletionOptions.DisableDefaultCmd = true
 }

--- a/cmd/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsgweb/commands/dmsgwebsrv.go
@@ -89,7 +89,7 @@ var srvCmd = &cobra.Command{
 		dlog = logging.MustGetLogger("dmsgwebsrv")
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)v
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}

--- a/cmd/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsgweb/commands/dmsgwebsrv.go
@@ -89,7 +89,7 @@ var srvCmd = &cobra.Command{
 		dlog = logging.MustGetLogger("dmsgwebsrv")
 
 		if dmsgHTTPPath != "" {
-			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)v
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint
 			if err != nil {
 				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 			}

--- a/cmd/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsgweb/commands/dmsgwebsrv.go
@@ -48,6 +48,7 @@ func init() {
 	srvCmd.Flags().UintSliceVarP(&dmsgPort, "dport", "d", dmsgPort, "DMSG port(s) to serve\033[0m\n\r")
 	srvCmd.Flags().StringSliceVarP(&wl, "wl", "w", wl, "whitelisted keys for DMSG authenticated routes\033[0m\n\r")
 	srvCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDisc, "DMSG discovery URL\033[0m\n\r")
+	srvCmd.Flags().StringVarP(&dmsgHTTPPath, "dmsgconf", "F", "", "dmsghttp-config path\033[0m\n\r")
 	srvCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", proxyAddr, "connect to DMSG via proxy (e.g., '127.0.0.1:1080')\033[0m\n\r")
 	srvCmd.Flags().IntVarP(&dmsgSess, "dsess", "e", dmsgSess, "DMSG sessions\033[0m\n\r")
 	srvCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP, comma separated\033[0m\n\r")
@@ -76,6 +77,18 @@ var srvCmd = &cobra.Command{
 			}
 		}
 		dlog = logging.MustGetLogger("dmsgwebsrv")
+
+		if dmsgHTTPPath != "" {
+			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath)
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
+			}
+			err = dmsg.InitConfig()
+			if err != nil {
+				dlog.WithError(err).Fatal("Failed to unmarshal dmsghttp-config")
+			}
+		}
+
 		if len(localPort) != len(dmsgPort) || len(localPort) != len(rawTCP) {
 			dlog.Fatal("The number of local ports, DMSG ports, and raw TCP flags must be the same")
 		}

--- a/cmd/dmsgweb/commands/root.go
+++ b/cmd/dmsgweb/commands/root.go
@@ -54,6 +54,7 @@ var (
 	httpClient         *http.Client //nolint unused
 	dialer             proxy.Dialer = proxy.Direct
 	useHTTP            bool
+	dmsgHTTPPath       string
 )
 
 // Execute executes root CLI command.

--- a/pkg/dmsg/const.go
+++ b/pkg/dmsg/const.go
@@ -61,6 +61,7 @@ func init() {
 	}
 }
 
+// InitConfig initialized the config
 func InitConfig() error {
 	var envServices skywire.EnvServices
 	err := json.Unmarshal(DmsghttpJSON, &envServices)

--- a/pkg/dmsg/const.go
+++ b/pkg/dmsg/const.go
@@ -55,17 +55,25 @@ type DmsghttpConfig struct {
 }
 
 func init() {
+	err := InitConfig()
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+func InitConfig() error {
 	var envServices skywire.EnvServices
 	err := json.Unmarshal(DmsghttpJSON, &envServices)
 	if err != nil {
-		log.Panic(err)
+		return err
 	}
 	err = json.Unmarshal(envServices.Prod, &Prod)
 	if err != nil {
-		log.Panic(err)
+		return err
 	}
 	err = json.Unmarshal(envServices.Test, &Test)
 	if err != nil {
-		log.Panic(err)
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
I've added a flag to the dmsg utilities which allows the user to specify their own custom dmsghttp-config.json & override the embedded default deployment config.