### PR TITLE
Stop on `Ctrl+C`

### DIFF
--- a/cmd/dmsg-socks5/commands/dmsg-socks5.go
+++ b/cmd/dmsg-socks5/commands/dmsg-socks5.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"time"
@@ -101,13 +100,6 @@ var serveCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 	Run: func(_ *cobra.Command, _ []string) {
 		dlog = logging.MustGetLogger("dmsg-proxy")
-		interrupt := make(chan os.Signal, 1)
-		signal.Notify(interrupt, os.Interrupt)
-		go func() {
-			<-interrupt
-			dlog.Info("Interrupt received. Shutting down...")
-			os.Exit(0)
-		}()
 
 		if dmsgHTTPPath != "" {
 			dmsg.DmsghttpJSON, err = os.ReadFile(dmsgHTTPPath) //nolint

--- a/cmd/dmsg/commands/kill.go
+++ b/cmd/dmsg/commands/kill.go
@@ -1,0 +1,23 @@
+// Package commands cmd/.../commands/kill.go
+package commands
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func init() {
+	//the application must stop on ctrl+c
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		sigCount := 0
+		for range c {
+			sigCount++
+			if sigCount >= 3 {
+				os.Exit(1)
+			}
+		}
+	}()
+}

--- a/cmd/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsgweb/commands/dmsgweb.go
@@ -157,13 +157,6 @@ dmsgweb conf file detected: ` + dwcfg
 		}
 	},
 	Run: func(_ *cobra.Command, _ []string) {
-		//		c := make(chan os.Signal, 1)
-		//		signal.Notify(c, os.Interrupt, syscall.SIGTERM) //nolint
-		//		go func() {
-		//			<-c
-		//			os.Exit(0)
-		//		}()
-
 		ctx, cancel := cmdutil.SignalContext(context.Background(), dlog)
 		defer cancel()
 

--- a/cmd/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsgweb/commands/dmsgwebsrv.go
@@ -117,7 +117,6 @@ var srvCmd = &cobra.Command{
 }
 
 func server() {
-
 	ctx, cancel := cmdutil.SignalContext(context.Background(), dlog)
 	defer cancel()
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6
 	github.com/skycoin/skycoin v0.28.1-0.20241105130348-39b49a2d0a7f //DO NOT MODIFY OR UPDATE v0.28.1-0.20241105130348-39b49a2d0a7f
-	github.com/skycoin/skywire v1.3.29-rc7.0.20250513064423-44197bc76ba7
+	github.com/skycoin/skywire v1.3.29-rc7.0.20250520183323-190aec794bf9
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/net v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6 h1:1Nc5EBY6pjfw1kwW0
 github.com/skycoin/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:UXghlricA7J3aRD/k7p/zBObQfmBawwCxIVPVjz2Q3o=
 github.com/skycoin/skycoin v0.28.1-0.20241105130348-39b49a2d0a7f h1:isCGulVHahQfFoS37B7JT3rb8n4Ih2o9oMg2p25D7o8=
 github.com/skycoin/skycoin v0.28.1-0.20241105130348-39b49a2d0a7f/go.mod h1:1iZLomiHUOEvmJaBNrzE+Tllf09uhrCZ5JLL3cHdKKQ=
-github.com/skycoin/skywire v1.3.29-rc7.0.20250513064423-44197bc76ba7 h1:5oiCiMzE9EXE8Yq0UMGxoFeDeL/dXDpMvNAHU/j4f98=
-github.com/skycoin/skywire v1.3.29-rc7.0.20250513064423-44197bc76ba7/go.mod h1:z4m1oegGW+BTmmJaA/u3dH6UTNLIx0QpgmsSte82G/8=
+github.com/skycoin/skywire v1.3.29-rc7.0.20250520183323-190aec794bf9 h1:Rl0TIrJLOVFvufFZ7CpMKCHuTon3eqfvSqNlHJlmo4o=
+github.com/skycoin/skywire v1.3.29-rc7.0.20250520183323-190aec794bf9/go.mod h1:HUKGwjK9zC1i4Q2cdDcPyCEALzdhivKg23q9MTVOUQc=
 github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -206,7 +206,7 @@ github.com/skycoin/skycoin/src/cipher/ripemd160
 github.com/skycoin/skycoin/src/cipher/secp256k1-go
 github.com/skycoin/skycoin/src/cipher/secp256k1-go/secp256k1-go2
 github.com/skycoin/skycoin/src/util/logging
-# github.com/skycoin/skywire v1.3.29-rc7.0.20250513064423-44197bc76ba7
+# github.com/skycoin/skywire v1.3.29-rc7.0.20250520183323-190aec794bf9
 ## explicit; go 1.24
 github.com/skycoin/skywire
 github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo


### PR DESCRIPTION
This PR fixes the failure to shut down with `ctrl+c` of all dmsg subcommands by the inclusion of a kill loop in the command wrapper init function.

it will kill the application / subcommand after 3 X `ctrl+c` which permits any graceful shutdown logic to attempt to work,, rather than just killing the application instantly

This may not be the best thing to put in an init function, as it should only be done once and has the potential to affect lots of other things. However, it's possible to work around this entirely since it's only included in the command wrapper. But again it will affect anything that imports the wrapper - i.e. skywire.

We need better process control. Perhaps this is a first step in that direction.