### PR TITLE
Add discovery endpoints to list clients by server

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -424,6 +424,16 @@ func (c *cachingDiscClient) AllEntries(ctx context.Context) ([]string, error) {
 	return c.base.AllEntries(ctx)
 }
 
+// AllClientsByServer delegates to base client
+func (c *cachingDiscClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
+	return c.base.AllClientsByServer(ctx)
+}
+
+// ClientsByServer delegates to base client
+func (c *cachingDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	return c.base.ClientsByServer(ctx, serverPK)
+}
+
 // fallbackDiscClient tries direct client first, falls back to HTTP discovery for unknown entries
 type fallbackDiscClient struct {
 	direct disc.APIClient
@@ -481,6 +491,16 @@ func (f *fallbackDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, err
 // AllEntries delegates to direct client
 func (f *fallbackDiscClient) AllEntries(ctx context.Context) ([]string, error) {
 	return f.direct.AllEntries(ctx)
+}
+
+// AllClientsByServer delegates to HTTP client
+func (f *fallbackDiscClient) AllClientsByServer(ctx context.Context) (map[string][]*disc.Entry, error) {
+	return f.http.AllClientsByServer(ctx)
+}
+
+// ClientsByServer delegates to HTTP client
+func (f *fallbackDiscClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	return f.http.ClientsByServer(ctx, serverPK)
 }
 
 // FallbackRoundTripper tries multiple DMSG transports until one succeeds.

--- a/internal/dmsg-discovery/api/api.go
+++ b/internal/dmsg-discovery/api/api.go
@@ -93,6 +93,8 @@ func New(log logrus.FieldLogger, db store.Storer, m discmetrics.Metrics, testMod
 	r.Delete("/dmsg-discovery/deregister", api.deregisterEntry())
 	r.Get("/dmsg-discovery/available_servers", api.getAvailableServers())
 	r.Get("/dmsg-discovery/all_servers", api.getAllServers())
+	r.Get("/dmsg-discovery/servers/clients", api.allClientsByServer())
+	r.Get("/dmsg-discovery/server/{pk}/clients", api.clientsByServer())
 	r.Get("/health", api.serviceHealth)
 
 	return api
@@ -438,6 +440,65 @@ func (a *API) getAllServers() http.HandlerFunc {
 		}
 
 		a.writeJSON(w, r, http.StatusOK, entries)
+	}
+}
+
+// allClientsByServer returns all client entries grouped by the server they are delegated to
+// URI: /dmsg-discovery/servers/clients
+// Method: GET
+func (a *API) allClientsByServer() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		entries, err := a.db.AllClientEntries(r.Context())
+		if err != nil {
+			a.handleError(w, r, err)
+			return
+		}
+
+		result := make(map[string][]*disc.Entry)
+		for _, entry := range entries {
+			if entry.Client == nil {
+				continue
+			}
+			for _, serverPK := range entry.Client.DelegatedServers {
+				result[serverPK.Hex()] = append(result[serverPK.Hex()], entry)
+			}
+		}
+
+		a.writeJSON(w, r, http.StatusOK, result)
+	}
+}
+
+// clientsByServer returns all client entries delegated to a specific server
+// URI: /dmsg-discovery/server/{pk}/clients
+// Method: GET
+func (a *API) clientsByServer() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		serverPK := cipher.PubKey{}
+		if err := serverPK.UnmarshalText([]byte(chi.URLParam(r, "pk"))); err != nil {
+			a.handleError(w, r, disc.ErrBadInput)
+			return
+		}
+
+		entries, err := a.db.AllClientEntries(r.Context())
+		if err != nil {
+			a.handleError(w, r, err)
+			return
+		}
+
+		var result []*disc.Entry
+		for _, entry := range entries {
+			if entry.Client == nil {
+				continue
+			}
+			for _, delegatedPK := range entry.Client.DelegatedServers {
+				if delegatedPK == serverPK {
+					result = append(result, entry)
+					break
+				}
+			}
+		}
+
+		a.writeJSON(w, r, http.StatusOK, result)
 	}
 }
 

--- a/internal/dmsg-discovery/store/redis.go
+++ b/internal/dmsg-discovery/store/redis.go
@@ -249,3 +249,40 @@ func (r *redisStore) AllVisorEntries(ctx context.Context) ([]string, error) {
 	}
 	return clients, err
 }
+
+func (r *redisStore) AllClientEntries(ctx context.Context) ([]*disc.Entry, error) {
+	pks, err := r.client.SMembers(ctx, "clients").Result()
+	if err != nil {
+		log.WithError(err).Errorf("Failed to get clients (SMembers) from redis")
+		return nil, disc.ErrUnexpected
+	}
+
+	if len(pks) == 0 {
+		return nil, nil
+	}
+
+	payloads, err := r.client.MGet(ctx, pks...).Result()
+	if err != nil {
+		log.WithError(err).Errorf("Failed to get client entries (MGet) from redis")
+		return nil, disc.ErrUnexpected
+	}
+
+	var entries []*disc.Entry
+	for _, payload := range payloads {
+		if payload == nil {
+			continue
+		}
+
+		var entry *disc.Entry
+		if err := json.Unmarshal([]byte(payload.(string)), &entry); err != nil {
+			log.WithError(err).Warnf("Failed to unmarshal payload %s", payload.(string))
+			continue
+		}
+
+		if entry.Client != nil {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}

--- a/internal/dmsg-discovery/store/storer.go
+++ b/internal/dmsg-discovery/store/storer.go
@@ -49,6 +49,9 @@ type Storer interface {
 
 	// AllVisorEntries returns all clients PKs.
 	AllVisorEntries(ctx context.Context) ([]string, error)
+
+	// AllClientEntries returns all full client entries.
+	AllClientEntries(ctx context.Context) ([]*disc.Entry, error)
 }
 
 // Config configures the Store object.

--- a/internal/dmsg-discovery/store/testing.go
+++ b/internal/dmsg-discovery/store/testing.go
@@ -238,3 +238,21 @@ func (ms *MockStore) AllVisorEntries(_ context.Context) ([]string, error) {
 	}
 	return entries, nil
 }
+
+// AllClientEntries implements Storer AllClientEntries method for MockStore
+func (ms *MockStore) AllClientEntries(_ context.Context) ([]*disc.Entry, error) {
+	ms.mLock.RLock()
+	defer ms.mLock.RUnlock()
+
+	var entries []*disc.Entry
+	for _, payload := range ms.m {
+		var e disc.Entry
+		if err := json.Unmarshal(payload, &e); err != nil {
+			return nil, disc.ErrUnexpected
+		}
+		if e.Client != nil {
+			entries = append(entries, &e)
+		}
+	}
+	return entries, nil
+}

--- a/pkg/direct/client.go
+++ b/pkg/direct/client.go
@@ -101,3 +101,36 @@ func (c *directClient) AllEntries(_ context.Context) (entries []string, err erro
 	}
 	return entries, nil
 }
+
+// AllClientsByServer returns all client entries grouped by server public key
+func (c *directClient) AllClientsByServer(_ context.Context) (map[string][]*disc.Entry, error) {
+	c.mx.RLock()
+	defer c.mx.RUnlock()
+	result := make(map[string][]*disc.Entry)
+	for _, entry := range c.entries {
+		if entry.Client != nil {
+			for _, serverPK := range entry.Client.DelegatedServers {
+				result[serverPK.Hex()] = append(result[serverPK.Hex()], entry)
+			}
+		}
+	}
+	return result, nil
+}
+
+// ClientsByServer returns all client entries delegated to a specific server
+func (c *directClient) ClientsByServer(_ context.Context, serverPK cipher.PubKey) ([]*disc.Entry, error) {
+	c.mx.RLock()
+	defer c.mx.RUnlock()
+	var entries []*disc.Entry
+	for _, entry := range c.entries {
+		if entry.Client != nil {
+			for _, delegatedPK := range entry.Client.DelegatedServers {
+				if delegatedPK == serverPK {
+					entries = append(entries, entry)
+					break
+				}
+			}
+		}
+	}
+	return entries, nil
+}

--- a/pkg/disc/client.go
+++ b/pkg/disc/client.go
@@ -26,6 +26,8 @@ type APIClient interface {
 	AvailableServers(context.Context) ([]*Entry, error)
 	AllServers(context.Context) ([]*Entry, error)
 	AllEntries(ctx context.Context) ([]string, error)
+	AllClientsByServer(ctx context.Context) (map[string][]*Entry, error)
+	ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*Entry, error)
 }
 
 // HTTPClient represents a client that communicates with a dmsg-discovery service through http, it
@@ -347,6 +349,86 @@ func (c *httpClient) AllEntries(ctx context.Context) ([]string, error) {
 			return nil, err
 		}
 
+		return nil, errFromString(message.Message)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&entries)
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// AllClientsByServer returns all client entries grouped by server public key.
+func (c *httpClient) AllClientsByServer(ctx context.Context) (map[string][]*Entry, error) {
+	endpoint := c.address + "/dmsg-discovery/servers/clients"
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := c.client.Do(req)
+	if resp != nil {
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				c.log.WithError(err).Warn("Failed to close response body")
+			}
+		}()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var message HTTPMessage
+		err = json.NewDecoder(resp.Body).Decode(&message)
+		if err != nil {
+			return nil, err
+		}
+		return nil, errFromString(message.Message)
+	}
+
+	var result map[string][]*Entry
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// ClientsByServer returns all client entries delegated to a specific server.
+func (c *httpClient) ClientsByServer(ctx context.Context, serverPK cipher.PubKey) ([]*Entry, error) {
+	var entries []*Entry
+	endpoint := fmt.Sprintf("%s/dmsg-discovery/server/%s/clients", c.address, serverPK.Hex())
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := c.client.Do(req)
+	if resp != nil {
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				c.log.WithError(err).Warn("Failed to close response body")
+			}
+		}()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var message HTTPMessage
+		err = json.NewDecoder(resp.Body).Decode(&message)
+		if err != nil {
+			return nil, err
+		}
 		return nil, errFromString(message.Message)
 	}
 

--- a/pkg/disc/testing.go
+++ b/pkg/disc/testing.go
@@ -166,3 +166,36 @@ func (m *mockClient) AllEntries(_ context.Context) ([]string, error) {
 	}
 	return list, nil
 }
+
+// AllClientsByServer returns all client entries grouped by server public key
+func (m *mockClient) AllClientsByServer(_ context.Context) (map[string][]*Entry, error) {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+	result := make(map[string][]*Entry)
+	for _, e := range m.entries {
+		if e := e; e.Client != nil {
+			for _, serverPK := range e.Client.DelegatedServers {
+				result[serverPK.Hex()] = append(result[serverPK.Hex()], &e)
+			}
+		}
+	}
+	return result, nil
+}
+
+// ClientsByServer returns all client entries delegated to a specific server
+func (m *mockClient) ClientsByServer(_ context.Context, serverPK cipher.PubKey) ([]*Entry, error) {
+	m.mx.RLock()
+	defer m.mx.RUnlock()
+	var list []*Entry
+	for _, e := range m.entries {
+		if e := e; e.Client != nil {
+			for _, delegatedPK := range e.Client.DelegatedServers {
+				if delegatedPK == serverPK {
+					list = append(list, &e)
+					break
+				}
+			}
+		}
+	}
+	return list, nil
+}


### PR DESCRIPTION
Add GET /dmsg-discovery/servers/clients to return all client entries grouped by delegated server, and GET /dmsg-discovery/server/{pk}/clients for a single server. Includes store, API, and client implementations.

for use with the new network visualizer UI