### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.USERNAME }}
         password: ${{ secrets.TOKEN }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: deploy to docker
       run: |
         chmod +x ./docker/scripts/docker-push.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.25.*
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Requirements
         run: |
           sudo apt update
@@ -26,10 +26,10 @@ jobs:
     needs: linux
     runs-on: macos-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.25.*
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Requirements
         run: |
           brew install goreleaser
@@ -44,10 +44,10 @@ jobs:
     needs: darwin
     runs-on: windows-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.25.*
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Requirements
         shell: pwsh
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,15 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
           cache: true
           cache-dependency-path: go.sum
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
 
@@ -43,15 +43,15 @@ jobs:
   darwin:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
           cache: true
           cache-dependency-path: go.sum
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
 
@@ -64,9 +64,9 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
           cache: true


### PR DESCRIPTION
## Summary
Updates deprecated Node.js 20 actions before the June 2nd, 2026 deadline:

- `actions/checkout`: v3/v4 → v5
- `actions/setup-go`: v5 → v6
- `docker/login-action`: v2 → v4
- `golangci/golangci-lint-action`: v7 → v9

Affects: test.yml, release.yml, deploy.yml