### PR TITLE
Fix scriptExecString using bash syntax with sh interpreter

### DIFF
--- a/cmd/dmsgweb/commands/root.go
+++ b/cmd/dmsgweb/commands/root.go
@@ -98,7 +98,7 @@ func scriptExecString(s, envfile string) string {
 		}
 		return defaultvalue
 	}
-	z, err := script.Exec(fmt.Sprintf(`sh -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`, envfile, s)).String()
+	z, err := script.Exec(fmt.Sprintf(`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`, envfile, s)).String()
 	if err == nil {
 		return strings.TrimSpace(z)
 	}
@@ -239,7 +239,7 @@ func scriptExecInt(s, envfile string) int {
 		}
 		return 0
 	}
-	z, err := script.Exec(fmt.Sprintf(`sh -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`, envfile, s)).String()
+	z, err := script.Exec(fmt.Sprintf(`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`, envfile, s)).String()
 	if err == nil {
 		if z == "" {
 			return 0
@@ -279,7 +279,7 @@ func scriptExecUint(s, envfile string) uint {
 		}
 		return 0
 	}
-	z, err := script.Exec(fmt.Sprintf(`sh -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`, envfile, s)).String()
+	z, err := script.Exec(fmt.Sprintf(`bash -c 'SKYENV=%s ; if [[ $SKYENV != "" ]] && [[ -f $SKYENV ]] ; then source $SKYENV ; fi ; printf "%s"'`, envfile, s)).String()
 	if err == nil {
 		if z == "" {
 			return 0


### PR DESCRIPTION
## Summary
- `scriptExecString` and `scriptExecUint` used `sh -c` with bash-only syntax (`[[ ]]` and `source`)
- On systems where `sh` is dash/POSIX sh (Arch Linux, Ubuntu, etc.), this produces `sh: 1: [[: not found`
- The error string leaked into cobra flag defaults, showing as: `--addproxy string (default "sh: 1: [[: not found")`
- Fix: change `sh -c` to `bash -c` to match the other `scriptExec*` functions which already use `bash -c`

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run` clean
- [x] `skywire dmsg web --help` no longer shows shell errors in flag defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)