### PR TITLE
Fix server goroutine leak: add deadline to forwardRequest handshake

### DIFF
--- a/pkg/dmsg/server_session.go
+++ b/pkg/dmsg/server_session.go
@@ -366,11 +366,21 @@ func (ss *ServerSession) forwardRequest(req StreamRequest) (mStr io.ReadWriteClo
 			return nil, nil, err
 		}
 	}
+	// Set a deadline for the forwarding handshake. If the destination visor
+	// accepts the stream but never responds, readObject blocks forever,
+	// leaking goroutines. Observed as 2K+ stuck goroutines per DMSG server.
+	if conn, ok := mStr.(net.Conn); ok {
+		conn.SetDeadline(time.Now().Add(HandshakeTimeout)) //nolint:errcheck,gosec
+	}
 	if err = ss.writeObject(mStr, req.raw); err != nil {
 		return nil, nil, err
 	}
 	if respObj, err = ss.readObject(mStr); err != nil {
 		return nil, nil, err
+	}
+	// Clear deadline before returning the stream for long-lived bridging.
+	if conn, ok := mStr.(net.Conn); ok {
+		conn.SetDeadline(time.Time{}) //nolint:errcheck,gosec
 	}
 	var resp StreamResponse
 	if resp, err = respObj.ObtainStreamResponse(); err != nil {


### PR DESCRIPTION
## Summary
Add HandshakeTimeout deadline to forwardRequest's readObject call.

## Root cause
forwardRequest opens a yamux stream to the destination visor and reads the handshake response. If the destination accepts the stream but never responds (dead visor, stuck process), readObject blocks forever. Observed as 2,400+ stuck goroutines per DMSG server minutes after restart.

The idle timeout fix (PR #372) only covered the bridge phase after handshake completion. The forwardRequest handshake itself had no timeout.

## Fix
Set HandshakeTimeout deadline before write/read, clear it after handshake completes (before returning the stream for long-lived bridging).